### PR TITLE
feat(cms-frontend): implement multiple deletion of genres

### DIFF
--- a/packages/backend/src/modules/genres/genres.repository.ts
+++ b/packages/backend/src/modules/genres/genres.repository.ts
@@ -181,6 +181,7 @@ export class GenresRepository extends TransactionalRepository<Genre> {
 
     const genresInUse = await this.createQueryBuilder('genre')
       .innerJoin('genre.artworks', 'artwork')
+      .leftJoinAndSelect('genre.translations', 'translation')
       .where('genre.id IN (:...ids)', { ids })
       .getMany();
 
@@ -189,7 +190,9 @@ export class GenresRepository extends TransactionalRepository<Genre> {
         GenreErrorCode.IN_USE,
         'Some of the genres are in use by artworks',
         {
-          ids: genresInUse.map((g) => g.id),
+          koNames: genresInUse.map(
+            (g) => g.translations.find((t) => t.language === Language.KO)?.name,
+          ),
         },
       );
     }

--- a/packages/cms-frontend/package.json
+++ b/packages/cms-frontend/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@icons-pack/react-simple-icons": "^10.2.0",
     "@minhoyunlife/my-ts-client": "1.3.3",
+    "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.3",

--- a/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/create.tsx
+++ b/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/create.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 
 import { Form } from "@/src/components/(authenticated)/form/form";
 import { FormField } from "@/src/components/(authenticated)/form/form-field";
-import { useCreateGenre } from "@/src/hooks/genres/use-genre-create";
+import { useCreateGenreMutation } from "@/src/hooks/genres/use-genre-create-mutation";
 import { useToast } from "@/src/hooks/use-toast";
 import { handleGenreError } from "@/src/lib/utils/errors/genre";
 import {
@@ -12,7 +12,7 @@ import {
 } from "@/src/schemas/genres/create";
 
 export function CreateGenreForm({ onSuccess }: { onSuccess?: () => void }) {
-  const createGenreMutation = useCreateGenre();
+  const createGenreMutation = useCreateGenreMutation();
   const { toast } = useToast();
   const {
     register,

--- a/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/delete.tsx
+++ b/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/delete.tsx
@@ -1,0 +1,48 @@
+import { ConfirmDialog } from "@/src/components/(authenticated)/confirm-dialog";
+import { useDeleteGenresMutation } from "@/src/hooks/genres/use-delete-genres-mutation";
+import { useToast } from "@/src/hooks/use-toast";
+import { handleGenreError } from "@/src/lib/utils/errors/genre";
+
+interface DeleteGenresDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onSuccess?: () => void;
+}
+
+export function DeleteGenresDialog({
+  open,
+  onOpenChange,
+  selectedIds,
+  onSuccess,
+}: DeleteGenresDialogProps) {
+  const { toast } = useToast();
+
+  const deleteGenresMutation = useDeleteGenresMutation();
+
+  const handleDelete = async () => {
+    try {
+      await deleteGenresMutation.mutateAsync({ ids: selectedIds });
+      toast({
+        title: "장르가 삭제되었습니다",
+      });
+
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (error) {
+      handleGenreError(error, toast, "장르 삭제 중 에러가 발생했습니다");
+    }
+  };
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="장르 삭제"
+      description={`선택한 ${selectedIds.length}개의 장르를 삭제하시겠습니까? 삭제된 장르는 복구할 수 없습니다.`}
+      confirmLabel="삭제"
+      variant="destructive"
+      onConfirm={handleDelete}
+    />
+  );
+}

--- a/packages/cms-frontend/src/components/(authenticated)/confirm-dialog.tsx
+++ b/packages/cms-frontend/src/components/(authenticated)/confirm-dialog.tsx
@@ -1,0 +1,59 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/src/components/base/alert-dialog";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  variant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={
+              variant === "destructive"
+                ? "bg-destructive hover:bg-destructive/90"
+                : undefined
+            }
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/cms-frontend/src/components/(authenticated)/page-wrapper.tsx
+++ b/packages/cms-frontend/src/components/(authenticated)/page-wrapper.tsx
@@ -21,7 +21,7 @@ export function PageWrapper({ children, title }: PageWrapperProps) {
           {title}
         </h2>
       </header>
-      <div className="flex flex-1 flex-col gap-4 p-4">{children}</div>
+      <div className="relative flex flex-1 flex-col gap-4 p-4">{children}</div>
     </>
   );
 }

--- a/packages/cms-frontend/src/components/(authenticated)/selected-action-bar.tsx
+++ b/packages/cms-frontend/src/components/(authenticated)/selected-action-bar.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/src/components/base/button";
+
+type ActionButton = {
+  label: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  variant?: "default" | "destructive" | "outline" | "secondary" | "ghost";
+  onClick: () => void;
+};
+
+interface SelectionActionBarProps {
+  selectedCount: number;
+  itemLabel?: string;
+  actions: ActionButton[];
+}
+
+export function SelectionActionBar({
+  selectedCount,
+  itemLabel = "항목",
+  actions,
+}: SelectionActionBarProps) {
+  return (
+    <div className="absolute border-b inset-x-0 top-0 z-50 bg-sidebar backdrop-blur-sm flex justify-center p-4">
+      <div className="container flex h-16 items-center justify-between">
+        <p className="text-sm font-medium">
+          {selectedCount} 개의 {itemLabel} 선택됨
+        </p>
+        <div className="flex gap-2">
+          {actions.map((action, index) => {
+            const Icon = action.icon;
+            return (
+              <Button
+                key={index}
+                variant={action.variant ?? "default"}
+                size="sm"
+                onClick={action.onClick}
+                className="gap-2"
+              >
+                {Icon && <Icon className="h-4 w-4" />}
+                {action.label}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/cms-frontend/src/components/base/alert-dialog.tsx
+++ b/packages/cms-frontend/src/components/base/alert-dialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { buttonVariants } from "@/src/components/base/button";
+import { cn } from "@/src/lib/utils/tailwindcss/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/packages/cms-frontend/src/constants/genres/error-messages.ts
+++ b/packages/cms-frontend/src/constants/genres/error-messages.ts
@@ -27,10 +27,10 @@ export const GENRE_ERROR_MESSAGES = {
     },
   },
   [GenreErrorCode.IN_USE]: {
-    title: "작품에서 사용 중인 장르입니다",
+    title: "일부 장르가 현재 작품에서 사용중입니다",
     formatDescription: (errors?: GenreErrorDetail) => {
-      if (!errors?.ids?.length) return "";
-      return `사용 중인 장르 ID: ${errors.ids.join(", ")}`;
+      if (!errors?.koNames?.length) return "";
+      return `해당 장르명: ${errors.koNames.join(", ")}`;
     },
   },
   [GenreErrorCode.INVALID_INPUT_DATA]: {

--- a/packages/cms-frontend/src/hooks/genres/use-delete-genres-mutation.ts
+++ b/packages/cms-frontend/src/hooks/genres/use-delete-genres-mutation.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { genresApi } from "@/src/lib/api/client";
+
+interface DeleteGenresVariables {
+  ids: string[];
+}
+
+export function useDeleteGenresMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ ids }: DeleteGenresVariables) =>
+      genresApi.deleteGenres(new Set(ids)),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["genres"] });
+    },
+  });
+}

--- a/packages/cms-frontend/src/hooks/genres/use-genre-create-mutation.ts
+++ b/packages/cms-frontend/src/hooks/genres/use-genre-create-mutation.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { genresApi } from "@/src/lib/api/client";
 import type { CreateGenreFormData } from "@/src/schemas/genres/create";
 
-export function useCreateGenre() {
+export function useCreateGenreMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/create.test.tsx
+++ b/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/create.test.tsx
@@ -7,8 +7,8 @@ vi.mock("@/src/hooks/genres/use-genre-create");
 vi.mock("@/src/hooks/use-toast");
 
 const mockMutateAsync = vi.fn();
-vi.mock("@/src/hooks/genres/use-genre-create", () => ({
-  useCreateGenre: () => ({
+vi.mock("@/src/hooks/genres/use-genre-create-mutation", () => ({
+  useCreateGenreMutation: () => ({
     mutateAsync: mockMutateAsync,
     isPending: false,
   }),

--- a/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/delete.test.tsx
+++ b/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/delete.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { DeleteGenresDialog } from "@/src/app/(authenticated)/genres/(actions)/delete";
+import { wrapper } from "@/test/utils/test-query-client";
+
+const mockMutateAsync = vi.fn();
+vi.mock("@/src/hooks/genres/use-delete-genres-mutation", () => ({
+  useDeleteGenresMutation: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/src/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe("DeleteGenresDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    selectedIds: ["genre-1", "genre-2"],
+    onSuccess: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("선택된 장르 수가 다이얼로그 설명에 표시됨", () => {
+    render(<DeleteGenresDialog {...defaultProps} />, { wrapper });
+
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+  });
+
+  it("삭제 확인 시 장르가 삭제됨", async () => {
+    mockMutateAsync.mockResolvedValueOnce({});
+
+    render(<DeleteGenresDialog {...defaultProps} />, { wrapper });
+
+    await userEvent.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        ids: defaultProps.selectedIds,
+      });
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+      expect(defaultProps.onSuccess).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalled();
+    });
+  });
+
+  it("API 에러 발생 시 에러 토스트를 표시함", async () => {
+    const mockError = {
+      isAxiosError: true,
+      response: {
+        data: {
+          code: "IN_USE",
+          errors: {
+            koNames: ["액션"],
+          },
+        },
+      },
+    };
+    mockMutateAsync.mockRejectedValueOnce(mockError);
+
+    render(<DeleteGenresDialog {...defaultProps} />, { wrapper });
+
+    await userEvent.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  it("취소 버튼 클릭 시 다이얼로그가 닫힘", async () => {
+    render(<DeleteGenresDialog {...defaultProps} />, { wrapper });
+
+    await userEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/cms-frontend/test/app/(authenticated)/genres/page.test.tsx
+++ b/packages/cms-frontend/test/app/(authenticated)/genres/page.test.tsx
@@ -1,4 +1,5 @@
 import GenresListPage from "@/src/app/(authenticated)/genres/page";
+import { wrapper } from "@/test/utils/test-query-client";
 
 const mockUseGenreListQuery = vi.fn();
 vi.mock("@/src/hooks/genres/use-genre-list-query", () => ({
@@ -47,7 +48,7 @@ describe("GenresListPage", () => {
   describe("화면 렌더링 검증", () => {
     describe("기본 화면 요소", () => {
       it("제목, 검색, 테이블이 표시됨", () => {
-        render(<GenresListPage />);
+        render(<GenresListPage />, { wrapper });
 
         expect(reactScreen.getByRole("heading")).toHaveTextContent("장르 목록");
         expect(
@@ -65,7 +66,7 @@ describe("GenresListPage", () => {
           error: null,
         });
 
-        render(<GenresListPage />);
+        render(<GenresListPage />, { wrapper });
 
         expect(
           reactScreen.getByTestId("data-table-skeleton"),
@@ -77,7 +78,7 @@ describe("GenresListPage", () => {
   describe("동작 검증", () => {
     describe("검색 동작", () => {
       it("검색어 입력 시 API 파라미터가 갱신됨", () => {
-        render(<GenresListPage />);
+        render(<GenresListPage />, { wrapper });
 
         const searchInput = reactScreen.getByPlaceholderText("장르명 검색...");
         fireEvent.change(searchInput, { target: { value: "액션" } });
@@ -100,7 +101,7 @@ describe("GenresListPage", () => {
         error: new Error("API Error"),
       });
 
-      render(<GenresListPage />);
+      render(<GenresListPage />, { wrapper });
 
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/cms-frontend/test/components/(authenticated)/data-table/table.test.tsx
+++ b/packages/cms-frontend/test/components/(authenticated)/data-table/table.test.tsx
@@ -89,6 +89,70 @@ describe("DataTable", () => {
     });
   });
 
+  describe("행 선택", () => {
+    it("enableRowSelection이 true일 때 체크박스 열이 표시됨", () => {
+      render(
+        <DataTable
+          {...defaultProps}
+          enableRowSelection={true}
+        />,
+      );
+
+      expect(document.querySelectorAll('button[role="checkbox"]')).toHaveLength(
+        data.length + 1,
+      );
+    });
+
+    it("체크박스로 행을 선택하면 onSelectedIdsChange가 호출됨", () => {
+      const onSelectedIdsChange = vi.fn();
+      render(
+        <DataTable
+          {...defaultProps}
+          enableRowSelection={true}
+          selectedIds={[]}
+          onSelectedIdsChange={onSelectedIdsChange}
+        />,
+      );
+
+      const firstRowCheckbox = document.querySelectorAll(
+        'button[role="checkbox"]',
+      )[1];
+      fireEvent.click(firstRowCheckbox!);
+
+      expect(onSelectedIdsChange).toHaveBeenCalledWith(["1"]);
+    });
+
+    it("헤더 체크박스로 모든 행을 선택 가능함", () => {
+      const onSelectedIdsChange = vi.fn();
+      render(
+        <DataTable
+          {...defaultProps}
+          enableRowSelection={true}
+          selectedIds={[]}
+          onSelectedIdsChange={onSelectedIdsChange}
+        />,
+      );
+
+      const headerCheckbox = document.querySelector('button[role="checkbox"]');
+      fireEvent.click(headerCheckbox!);
+
+      expect(onSelectedIdsChange).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("enableRowSelection이 false면 체크박스 열이 표시되지 않음", () => {
+      render(
+        <DataTable
+          {...defaultProps}
+          enableRowSelection={false}
+        />,
+      );
+
+      expect(document.querySelectorAll('button[role="checkbox"]')).toHaveLength(
+        0,
+      );
+    });
+  });
+
   describe("페이지네이션", () => {
     it("pageCount에 따라 페이지네이션을 렌더링", () => {
       render(

--- a/packages/cms-frontend/test/hooks/genres/use-delete-genres-mutation.test.tsx
+++ b/packages/cms-frontend/test/hooks/genres/use-delete-genres-mutation.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+
+import { useDeleteGenresMutation } from "@/src/hooks/genres/use-delete-genres-mutation";
+import { genresApi } from "@/src/lib/api/client";
+import { wrapper } from "@/test/utils/test-query-client";
+
+vi.mock("@/src/lib/api/client", () => ({
+  genresApi: {
+    deleteGenres: vi.fn(),
+  },
+}));
+
+describe("useDeleteGenresMutation", () => {
+  const mockIds = ["genre-1", "genre-2"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("기본 동작", () => {
+    it("장르 삭제 API를 호출함", async () => {
+      vi.mocked(genresApi.deleteGenres).mockResolvedValueOnce({} as any);
+
+      const { result } = renderHook(() => useDeleteGenresMutation(), {
+        wrapper,
+      });
+
+      await result.current.mutateAsync({ ids: mockIds });
+
+      expect(genresApi.deleteGenres).toHaveBeenCalledWith(new Set(mockIds));
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("API 호출에 실패할 경우, 에러를 반환함", async () => {
+      const mockError = new Error("API Error");
+      vi.mocked(genresApi.deleteGenres).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useDeleteGenresMutation(), {
+        wrapper,
+      });
+
+      await expect(
+        result.current.mutateAsync({ ids: mockIds }),
+      ).rejects.toThrow(mockError);
+    });
+  });
+});

--- a/packages/cms-frontend/test/hooks/genres/use-genre-create-mutation.test.tsx
+++ b/packages/cms-frontend/test/hooks/genres/use-genre-create-mutation.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/src/lib/api/client", () => ({
   },
 }));
 
-describe("useCreateGenre", () => {
+describe("useCreateGenreMutation", () => {
   const mockCreateGenreData = {
     koName: "액션",
     enName: "Action",

--- a/packages/cms-frontend/test/hooks/genres/use-genre-create-mutation.test.tsx
+++ b/packages/cms-frontend/test/hooks/genres/use-genre-create-mutation.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 
-import { useCreateGenre } from "@/src/hooks/genres/use-genre-create";
+import { useCreateGenreMutation } from "@/src/hooks/genres/use-genre-create-mutation";
 import { genresApi } from "@/src/lib/api/client";
 import { wrapper } from "@/test/utils/test-query-client";
 
@@ -25,7 +25,9 @@ describe("useCreateGenre", () => {
     it("장르 생성 API를 호출함", async () => {
       vi.mocked(genresApi.createGenre).mockResolvedValueOnce({} as any);
 
-      const { result } = renderHook(() => useCreateGenre(), { wrapper });
+      const { result } = renderHook(() => useCreateGenreMutation(), {
+        wrapper,
+      });
 
       await result.current.mutateAsync(mockCreateGenreData);
 
@@ -38,7 +40,9 @@ describe("useCreateGenre", () => {
       const mockError = new Error("API Error");
       vi.mocked(genresApi.createGenre).mockRejectedValueOnce(mockError);
 
-      const { result } = renderHook(() => useCreateGenre(), { wrapper });
+      const { result } = renderHook(() => useCreateGenreMutation(), {
+        wrapper,
+      });
 
       await expect(
         result.current.mutateAsync(mockCreateGenreData),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.3
-        version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.3
         version: 2.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1519,19 +1519,6 @@ packages:
       '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dialog@1.1.3':
-    resolution: {integrity: sha512-ujGvqQNkZ0J7caQyl8XuZRj2/TIrYcOGwqz5TeD1OMcCdfBuEMP0D12ve+8J5F9XuNUth3FAKFWo/wt0E/GJrQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7518,28 +7505,6 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-remove-scroll: 2.5.5(@types/react@18.3.12)(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-
-  '@radix-ui/react-dialog@1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.12)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.2.0)
-      '@radix-ui/react-portal': 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.2.0)
-      aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.6.0(@types/react@18.3.12)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.3.12
       '@types/react-dom': 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@minhoyunlife/my-ts-client':
         specifier: 1.3.3
         version: 1.3.3
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.4
+        version: 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1377,6 +1380,19 @@ packages:
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
+  '@radix-ui/react-alert-dialog@1.1.4':
+    resolution: {integrity: sha512-A6Kh23qZDLy3PSU4bh2UJZznOrUdHImIXqF8YtUa6CN73f8EOO9XlXSCd9IHyPvIquTaa/kwaSWzZTtUvgXVGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.1':
     resolution: {integrity: sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==}
     peerDependencies:
@@ -1511,6 +1527,19 @@ packages:
 
   '@radix-ui/react-dialog@1.1.3':
     resolution: {integrity: sha512-ujGvqQNkZ0J7caQyl8XuZRj2/TIrYcOGwqz5TeD1OMcCdfBuEMP0D12ve+8J5F9XuNUth3FAKFWo/wt0E/GJrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.4':
+    resolution: {integrity: sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7357,6 +7386,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.1': {}
 
+  '@radix-ui/react-alert-dialog@1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-arrow@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7497,6 +7540,28 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-remove-scroll: 2.6.0(@types/react@18.3.12)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-dialog@1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.12)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.2.0)
+      aria-hidden: 1.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.6.2(@types/react@18.3.12)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.3.12
       '@types/react-dom': 18.3.1


### PR DESCRIPTION
## 관련 이슈
close #40 

## 작업 내용
- 장르 삭제용 다이얼로그 작성
- 행 선택이 가능하도록 테이블의 수정
- 행 선택 시 화면 상단에 액션 바가 표시되도록 구현
- 백엔드에서 일부 에러 메시지에 필요한 키가 적절하지 않다고 판단하여 수정
