### PR TITLE
fix: enable genre deletion at table's row level actions

### DIFF
--- a/packages/cms-frontend/src/app/(authenticated)/genres/columns.tsx
+++ b/packages/cms-frontend/src/app/(authenticated)/genres/columns.tsx
@@ -13,54 +13,62 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/base/dropdown-menu";
 
-export const genreColumns: ColumnDef<GetArtworks200ResponseItemsInnerAllOfGenresInner>[] =
-  [
-    {
-      id: "koName",
-      header: "한국어",
-      cell: ({ row }) =>
-        row.original.translations.find((t) => t.language === "ko")?.name ?? "-",
+interface GenreColumnProps {
+  onDeleteClick: (id: string) => void;
+}
+
+export const genreColumns = ({
+  onDeleteClick,
+}: GenreColumnProps): ColumnDef<GetArtworks200ResponseItemsInnerAllOfGenresInner>[] => [
+  {
+    id: "koName",
+    header: "한국어",
+    cell: ({ row }) =>
+      row.original.translations.find((t) => t.language === "ko")?.name ?? "-",
+  },
+  {
+    accessorKey: "enName",
+    header: "English",
+    cell: ({ row }) =>
+      row.original.translations.find((t) => t.language === "en")?.name ?? "-",
+  },
+  {
+    accessorKey: "jaName",
+    header: "日本語",
+    cell: ({ row }) =>
+      row.original.translations.find((t) => t.language === "ja")?.name ?? "-",
+  },
+  {
+    id: "actions",
+    header: "작업",
+    cell: ({ row }) => {
+      return (
+        <div className="flex justify-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className="h-8 w-8 p-0"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem>
+                <Pencil className="mr-2 h-4 w-4" />
+                <span>수정</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive"
+                onClick={() => onDeleteClick(row.original.id)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                <span>삭제</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      );
     },
-    {
-      accessorKey: "enName",
-      header: "English",
-      cell: ({ row }) =>
-        row.original.translations.find((t) => t.language === "en")?.name ?? "-",
-    },
-    {
-      accessorKey: "jaName",
-      header: "日本語",
-      cell: ({ row }) =>
-        row.original.translations.find((t) => t.language === "ja")?.name ?? "-",
-    },
-    {
-      id: "actions",
-      header: "작업",
-      cell: ({ row }) => {
-        return (
-          <div className="flex justify-center">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="h-8 w-8 p-0"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem>
-                  <Pencil className="mr-2 h-4 w-4" />
-                  <span>수정</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem className="text-destructive">
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  <span>삭제</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        );
-      },
-    },
-  ];
+  },
+];

--- a/packages/cms-frontend/src/app/(authenticated)/genres/page.tsx
+++ b/packages/cms-frontend/src/app/(authenticated)/genres/page.tsx
@@ -51,6 +51,11 @@ export default function GenresListPage() {
     setSearch(value);
   };
 
+  const handleSingleDelete = (id: string) => {
+    setSelectedGenreIds([id]);
+    setIsDeleteDialogOpen(true);
+  };
+
   useEffect(() => {
     if (error) {
       toast({
@@ -110,7 +115,7 @@ export default function GenresListPage() {
 
       {/* 장르 목록 테이블 */}
       <DataTable
-        columns={genreColumns}
+        columns={genreColumns({ onDeleteClick: handleSingleDelete })}
         data={genresResult?.data.items ?? []}
         isLoading={isGenresLoading}
         pageCount={genresResult?.data.metadata.totalPages}


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- 장르 삭제가 테이블의 각 행마다 존재하는 액션 일람에서도 작동하도록 수정
