### PR TITLE
feat(backend): implement deleteArtworks in backend

### DIFF
--- a/packages/backend/src/common/utils/retry.util.ts
+++ b/packages/backend/src/common/utils/retry.util.ts
@@ -1,0 +1,38 @@
+interface RetryOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  onError?: (error: Error, attempt: number) => void;
+}
+
+/**
+ * 작업을 지정된 횟수만큼 재시도하는 유틸리티 함수
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxAttempts = 3, delayMs = 1000, onError } = options;
+
+  let lastError: Error;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      console.log('attempt', attempt);
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (onError) {
+        onError(error, attempt);
+      }
+
+      if (attempt === maxAttempts) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/backend/src/modules/artworks/artworks.controller.ts
+++ b/packages/backend/src/modules/artworks/artworks.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -21,6 +22,7 @@ import {
   ArtworkResponse,
 } from '@/src/modules/artworks/dtos/artwork-response.dto';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
+import { DeleteArtworksDto } from '@/src/modules/artworks/dtos/delete-artworks.dto';
 import { GetArtworksQueryDto } from '@/src/modules/artworks/dtos/get-artworks-query.dto';
 import { ImageFileType } from '@/src/modules/artworks/enums/file-type.enum';
 import {
@@ -28,7 +30,10 @@ import {
   UploadImageException,
 } from '@/src/modules/artworks/exceptions/upload-image.exception';
 import { UploadImageExceptionFilter } from '@/src/modules/artworks/filters/upload-image.filter';
-import { OptionalBearerAuthGuard } from '@/src/modules/auth/guards/token.auth.guard';
+import {
+  BearerAuthGuard,
+  OptionalBearerAuthGuard,
+} from '@/src/modules/auth/guards/token.auth.guard';
 import { AdminUser } from '@/src/modules/auth/interfaces/admin-user.interface';
 import { StorageService } from '@/src/modules/storage/storage.service';
 
@@ -95,6 +100,7 @@ export class ArtworksController {
   }
 
   @Post()
+  @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.CREATED)
   async create(
     @Body() createArtworkDto: CreateArtworkDto,
@@ -104,6 +110,7 @@ export class ArtworksController {
   }
 
   @Post('images')
+  @UseGuards(BearerAuthGuard)
   @UseFilters(UploadImageExceptionFilter)
   @UseInterceptors(FileInterceptor('image', ArtworksController.UPLOAD_OPTIONS))
   @HttpCode(HttpStatus.CREATED)
@@ -115,5 +122,12 @@ export class ArtworksController {
       );
     }
     return this.storageService.uploadImage(image);
+  }
+
+  @Delete()
+  @UseGuards(BearerAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteArtworks(@Body() dto: DeleteArtworksDto): Promise<void> {
+    return this.artworksService.deleteArtworks(dto.ids);
   }
 }

--- a/packages/backend/src/modules/artworks/artworks.service.ts
+++ b/packages/backend/src/modules/artworks/artworks.service.ts
@@ -4,6 +4,7 @@ import { EntityManager, In } from 'typeorm';
 
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { EntityList } from '@/src/common/interfaces/entity-list.interface';
+import { withRetry } from '@/src/common/utils/retry.util';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
 import { GetArtworksQueryDto } from '@/src/modules/artworks/dtos/get-artworks-query.dto';
@@ -17,12 +18,15 @@ import {
 } from '@/src/modules/artworks/exceptions/artworks.exception';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
+import { ImageStatus } from '@/src/modules/storage/enums/status.enum';
+import { StorageService } from '@/src/modules/storage/storage.service';
 
 @Injectable()
 export class ArtworksService {
   constructor(
     private readonly artworksRepository: ArtworksRepository,
     private readonly genresRepository: GenresRepository,
+    private readonly storageService: StorageService,
     private readonly entityManager: EntityManager,
   ) {}
 
@@ -137,6 +141,38 @@ export class ArtworksService {
       };
 
       return await this.artworksRepository.createOne(artwork);
+    });
+  }
+
+  /**
+   * 복수의 기존 작품을 삭제
+   * @param id - 삭제할 작품의 ID
+   */
+  async deleteArtworks(ids: string[]): Promise<void> {
+    return this.entityManager.transaction(async (manager) => {
+      const artworksTxRepo = this.artworksRepository.forTransaction(manager);
+
+      const deletedArtworks = await artworksTxRepo.deleteMany(ids);
+
+      await Promise.all(
+        deletedArtworks.map((artwork) =>
+          withRetry(
+            () =>
+              this.storageService.changeImageTag(
+                artwork.imageKey,
+                ImageStatus.TO_DELETE,
+              ),
+            {
+              onError: (error, attempt) => {
+                console.error(
+                  `Failed to change image tag of artwork ${artwork.id} (attempt: ${attempt})`,
+                  error,
+                );
+              },
+            },
+          ),
+        ),
+      );
     });
   }
 }

--- a/packages/backend/src/modules/artworks/dtos/delete-artworks.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/delete-artworks.dto.ts
@@ -1,0 +1,15 @@
+import { Transform } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+
+export class DeleteArtworksDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return [value].filter(Boolean);
+    }
+    return Array.isArray(value) ? value.filter(Boolean) : value;
+  })
+  ids: string[];
+}

--- a/packages/backend/src/modules/artworks/exceptions/artworks.exception.ts
+++ b/packages/backend/src/modules/artworks/exceptions/artworks.exception.ts
@@ -4,10 +4,14 @@ import { BaseException } from '@/src/common/exceptions/base.exception';
 
 export enum ArtworkErrorCode {
   NOT_EXISTING_GENRES_INCLUDED = 'NOT_EXISTING_GENRES_INCLUDED',
+  NOT_FOUND = 'NOT_FOUND',
+  ALREADY_PUBLISHED = 'ALREADY_PUBLISHED',
 }
 
 export const ARTWORK_ERROR_STATUS_MAP: Record<ArtworkErrorCode, HttpStatus> = {
   [ArtworkErrorCode.NOT_EXISTING_GENRES_INCLUDED]: HttpStatus.BAD_REQUEST,
+  [ArtworkErrorCode.NOT_FOUND]: HttpStatus.NOT_FOUND,
+  [ArtworkErrorCode.ALREADY_PUBLISHED]: HttpStatus.CONFLICT,
 };
 
 export class ArtworkException extends BaseException {

--- a/packages/backend/src/modules/genres/dtos/delete-genres.dto.ts
+++ b/packages/backend/src/modules/genres/dtos/delete-genres.dto.ts
@@ -1,7 +1,7 @@
 import { Transform } from 'class-transformer';
 import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
 
-export class DeleteGenresQueryDto {
+export class DeleteGenresDto {
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })

--- a/packages/backend/src/modules/genres/genres.controller.ts
+++ b/packages/backend/src/modules/genres/genres.controller.ts
@@ -15,7 +15,7 @@ import {
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { BearerAuthGuard } from '@/src/modules/auth/guards/token.auth.guard';
 import { CreateGenreDto } from '@/src/modules/genres/dtos/create-genre.dto';
-import { DeleteGenresQueryDto } from '@/src/modules/genres/dtos/delete-genres-query.dto';
+import { DeleteGenresDto } from '@/src/modules/genres/dtos/delete-genres.dto';
 import {
   GenreListResponse,
   GenreResponse,
@@ -77,7 +77,7 @@ export class GenresController {
   @Delete()
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteGenre(@Query() query: DeleteGenresQueryDto): Promise<void> {
-    await this.genresService.deleteGenres(query.ids);
+  async deleteGenre(@Body() dto: DeleteGenresDto): Promise<void> {
+    await this.genresService.deleteGenres(dto.ids);
   }
 }

--- a/packages/backend/src/modules/storage/enums/status.enum.ts
+++ b/packages/backend/src/modules/storage/enums/status.enum.ts
@@ -1,0 +1,7 @@
+/**
+ * S3 상 이미지 오브젝트의 상태
+ */
+export enum ImageStatus {
+  ACTIVE = 'active',
+  TO_DELETE = 'toDelete',
+}

--- a/packages/backend/src/modules/storage/storage.service.ts
+++ b/packages/backend/src/modules/storage/storage.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  PutObjectCommand,
+  PutObjectTaggingCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { nanoid } from 'nanoid';
 import Sharp from 'sharp';
 
@@ -39,6 +43,11 @@ export class StorageService {
     this.bucket = this.configService.get('s3.bucket');
   }
 
+  getImageUrl(imageKey: string): string {
+    const cloudfrontDomain = this.configService.get('s3.cloudfrontDomain');
+    return `https://${cloudfrontDomain}/${imageKey}`;
+  }
+
   async uploadImage(file: Express.Multer.File): Promise<UploadResult> {
     const optimizedBuffer = await this.optimizeImage(file.buffer);
     const imageKey = this.generateImageKey();
@@ -56,9 +65,26 @@ export class StorageService {
     return { imageKey };
   }
 
-  getImageUrl(imageKey: string): string {
-    const cloudfrontDomain = this.configService.get('s3.cloudfrontDomain');
-    return `https://${cloudfrontDomain}/${imageKey}`;
+  /**
+   * S3 이미지 오브젝트의 status 태그 값을 변경
+   * @param imageKey - 변경할 이미지의 키
+   * @param status - 변경할 상태 값
+   */
+  async changeImageTag(imageKey: string, status: ImageStatus): Promise<void> {
+    await this.client.send(
+      new PutObjectTaggingCommand({
+        Bucket: this.bucket,
+        Key: imageKey,
+        Tagging: {
+          TagSet: [
+            {
+              Key: 'status',
+              Value: status,
+            },
+          ],
+        },
+      }),
+    );
   }
 
   private async optimizeImage(buffer: Buffer): Promise<Buffer> {

--- a/packages/backend/src/modules/storage/storage.service.ts
+++ b/packages/backend/src/modules/storage/storage.service.ts
@@ -6,6 +6,7 @@ import { nanoid } from 'nanoid';
 import Sharp from 'sharp';
 
 import { ImageFileType } from '@/src/modules/artworks/enums/file-type.enum';
+import { ImageStatus } from '@/src/modules/storage/enums/status.enum';
 
 type UploadResult = {
   imageKey: string;
@@ -48,6 +49,7 @@ export class StorageService {
         Key: imageKey,
         Body: optimizedBuffer,
         ContentType: ImageFileType.WEBP,
+        Tagging: `status=${ImageStatus.ACTIVE}`,
       }),
     );
 

--- a/packages/backend/test/common/utils/retry.util.spec.ts
+++ b/packages/backend/test/common/utils/retry.util.spec.ts
@@ -1,0 +1,53 @@
+import { withRetry } from '@/src/common/utils/retry.util';
+
+const mockOperation = vi.fn();
+
+describeWithoutDeps('withRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('성공 시 바로 결과를 반환함', async () => {
+    const operation = mockOperation.mockResolvedValue('success');
+    const result = await withRetry(operation);
+
+    expect(result).toBe('success');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('첫 번째 실패 시 재시도하여 성공한다면 결과를 반환함', async () => {
+    const operation = mockOperation
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce('success');
+
+    const result = await withRetry(operation);
+
+    expect(result).toBe('success');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('최대 시도 횟수 초과 시 마지막 에러가 반환됨', async () => {
+    const error = new Error('fail');
+    const operation = mockOperation.mockRejectedValue(error);
+
+    await expect(withRetry(operation, { maxAttempts: 2 })).rejects.toThrow(
+      error,
+    );
+
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('에러 발생 시 onError 콜백을 호출함', async () => {
+    const onError = vi.fn();
+    const operation = mockOperation
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValueOnce('success');
+
+    await withRetry(operation, { onError });
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenNthCalledWith(1, expect.any(Error), 1);
+    expect(onError).toHaveBeenNthCalledWith(2, expect.any(Error), 2);
+  });
+});

--- a/packages/backend/test/modules/artworks/dtos/delete-artworks.dto.spec.ts
+++ b/packages/backend/test/modules/artworks/dtos/delete-artworks.dto.spec.ts
@@ -1,0 +1,60 @@
+import { validate } from 'class-validator';
+
+import { DeleteArtworksDto } from '@/src/modules/artworks/dtos/delete-artworks.dto';
+import { createDto } from '@/test/utils/dto.util';
+
+describeWithoutDeps('DeleteArtworksDto', () => {
+  const validDtoData: Partial<DeleteArtworksDto> = {
+    ids: ['artwork-1', 'artwork-2'],
+  };
+
+  describe('ids', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(DeleteArtworksDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('단일 값이 주어진 경우, 배열화됨', async () => {
+      const dto = createDto(DeleteArtworksDto, validDtoData, {
+        ids: 'genre-1' as unknown as string[],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.ids).toEqual(['genre-1']);
+    });
+
+    it('빈 배열이 주어진 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteArtworksDto, validDtoData, { ids: [] });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('arrayNotEmpty');
+    });
+
+    it('빈 값으로 주어진 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteArtworksDto, validDtoData, {
+        ids: ['', ''],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('arrayNotEmpty');
+    });
+
+    it('값이 생략된 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteArtworksDto, validDtoData);
+      delete dto.ids;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('isArray');
+    });
+  });
+});

--- a/packages/backend/test/modules/genres/dtos/delete-genres.dto.spec.ts
+++ b/packages/backend/test/modules/genres/dtos/delete-genres.dto.spec.ts
@@ -1,23 +1,23 @@
 import { validate } from 'class-validator';
 
-import { DeleteGenresQueryDto } from '@/src/modules/genres/dtos/delete-genres-query.dto';
+import { DeleteGenresDto } from '@/src/modules/genres/dtos/delete-genres.dto';
 import { createDto } from '@/test/utils/dto.util';
 
-describeWithoutDeps('DeleteGenresQueryDto', () => {
-  const validDtoData: Partial<DeleteGenresQueryDto> = {
+describeWithoutDeps('DeleteGenresDto', () => {
+  const validDtoData: Partial<DeleteGenresDto> = {
     ids: ['genre-1', 'genre-2'],
   };
 
   describe('ids', () => {
     it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
-      const dto = createDto(DeleteGenresQueryDto, validDtoData);
+      const dto = createDto(DeleteGenresDto, validDtoData);
       const errors = await validate(dto);
 
       expect(errors).toHaveLength(0);
     });
 
     it('단일 값이 주어진 경우, 배열화됨', async () => {
-      const dto = createDto(DeleteGenresQueryDto, validDtoData, {
+      const dto = createDto(DeleteGenresDto, validDtoData, {
         ids: 'genre-1' as unknown as string[],
       });
       const errors = await validate(dto);
@@ -27,7 +27,7 @@ describeWithoutDeps('DeleteGenresQueryDto', () => {
     });
 
     it('빈 배열이 주어진 경우, 에러가 발생함', async () => {
-      const dto = createDto(DeleteGenresQueryDto, validDtoData, { ids: [] });
+      const dto = createDto(DeleteGenresDto, validDtoData, { ids: [] });
       const errors = await validate(dto);
 
       expect(errors).toHaveLength(1);
@@ -36,7 +36,7 @@ describeWithoutDeps('DeleteGenresQueryDto', () => {
     });
 
     it('빈 값으로 주어진 경우, 에러가 발생함', async () => {
-      const dto = createDto(DeleteGenresQueryDto, validDtoData, {
+      const dto = createDto(DeleteGenresDto, validDtoData, {
         ids: ['', ''],
       });
       const errors = await validate(dto);
@@ -47,7 +47,7 @@ describeWithoutDeps('DeleteGenresQueryDto', () => {
     });
 
     it('값이 생략된 경우, 에러가 발생함', async () => {
-      const dto = createDto(DeleteGenresQueryDto, validDtoData);
+      const dto = createDto(DeleteGenresDto, validDtoData);
       delete dto.ids;
 
       const errors = await validate(dto);

--- a/packages/backend/test/modules/genres/genres.controller.spec.ts
+++ b/packages/backend/test/modules/genres/genres.controller.spec.ts
@@ -11,6 +11,7 @@ import { Administrator } from '@/src/modules/auth/entities/administrator.entity'
 import { TokenErrorCode } from '@/src/modules/auth/exceptions/token.exception';
 import { INVALID_INPUT_DATA } from '@/src/modules/config/settings/validation-pipe.config';
 import { CreateGenreDto } from '@/src/modules/genres/dtos/create-genre.dto';
+import { DeleteGenresDto } from '@/src/modules/genres/dtos/delete-genres.dto';
 import { UpdateGenreDto } from '@/src/modules/genres/dtos/update-genre.dto';
 import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
@@ -467,12 +468,16 @@ describeWithDeps('GenresController', () => {
     });
 
     it('유효한 ID 목록으로 장르 삭제 시 성공적으로 처리됨', async () => {
+      const deleteDto: DeleteGenresDto = {
+        ids: [genres[0].id, genres[1].id],
+      };
+
       const token = await createTestAccessToken(authService, administrator);
 
       const response = await request(app.getHttpServer())
         .delete('/genres')
         .set('Authorization', `Bearer ${token}`)
-        .query({ ids: [genres[0].id, genres[1].id] })
+        .send(deleteDto)
         .expect(204);
 
       await expect(response).toMatchOpenAPISpec();
@@ -483,23 +488,27 @@ describeWithDeps('GenresController', () => {
       expect(saved).toEqual([]);
     });
 
-    it('쿼리 파라미터가 부적절할 경우, 400 에러가 반환됨', async () => {
+    it('리퀘스트 바디가 부적절할 경우, 400 에러가 반환됨', async () => {
       const token = await createTestAccessToken(authService, administrator);
 
       const response = await request(app.getHttpServer())
         .delete('/genres')
         .set('Authorization', `Bearer ${token}`)
-        .query({ ids: [] })
+        .send({ ids: [] })
         .expect(400);
 
       await expect(response).toMatchOpenAPISpec();
     });
 
     it('인증에 실패한 경우, 401 에러가 반환됨', async () => {
+      const deleteDto: DeleteGenresDto = {
+        ids: [genres[0].id, genres[1].id],
+      };
+
       const response = await request(app.getHttpServer())
         .delete('/genres')
         .set('Authorization', 'Bearer invalid-token')
-        .query({ ids: [genres[0].id, genres[1].id] })
+        .send(deleteDto)
         .expect(401);
 
       await expect(response).toMatchOpenAPISpec();
@@ -511,7 +520,7 @@ describeWithDeps('GenresController', () => {
       const response = await request(app.getHttpServer())
         .delete('/genres')
         .set('Authorization', `Bearer ${token}`)
-        .query({ ids: ['invalid-id'] })
+        .send({ ids: ['invalid-id'] })
         .expect(404);
 
       await expect(response).toMatchOpenAPISpec();
@@ -523,7 +532,7 @@ describeWithDeps('GenresController', () => {
       const response = await request(app.getHttpServer())
         .delete('/genres')
         .set('Authorization', `Bearer ${token}`)
-        .query({ ids: [genres[2].id] })
+        .send({ ids: [genres[2].id] })
         .expect(409);
 
       await expect(response).toMatchOpenAPISpec();

--- a/packages/backend/test/modules/storage/storage.service.spec.ts
+++ b/packages/backend/test/modules/storage/storage.service.spec.ts
@@ -1,7 +1,8 @@
-import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, GetObjectTaggingCommand } from '@aws-sdk/client-s3';
 import Sharp from 'sharp';
 
 import { ImageFileType } from '@/src/modules/artworks/enums/file-type.enum';
+import { ImageStatus } from '@/src/modules/storage/enums/status.enum';
 import { StorageService } from '@/src/modules/storage/storage.service';
 import { TEST_S3_CONFIG } from '@/test/test.config';
 import { createTestingModuleWithoutDB } from '@/test/utils/module-builder.util';
@@ -47,18 +48,32 @@ describeWithDeps('StorageService', () => {
     it('이미지가 성공적으로 업로드 됨', async () => {
       const result = await service.uploadImage(imageData);
 
-      const { Body } = await service.client.send(
-        new GetObjectCommand({
-          Bucket: TEST_S3_CONFIG.bucket,
-          Key: result.imageKey,
-        }),
-      );
+      const [{ Body }, { TagSet }] = await Promise.all([
+        service.client.send(
+          new GetObjectCommand({
+            Bucket: TEST_S3_CONFIG.bucket,
+            Key: result.imageKey,
+          }),
+        ),
+        service.client.send(
+          new GetObjectTaggingCommand({
+            Bucket: TEST_S3_CONFIG.bucket,
+            Key: result.imageKey,
+          }),
+        ),
+      ]);
 
       const uploadedBuffer = Buffer.from(
         await Body.transformToString('binary'),
         'binary',
       );
+
       expect(uploadedBuffer.length).toBeGreaterThan(0);
+      expect(TagSet).toHaveLength(1);
+      expect(TagSet[0]).toEqual({
+        Key: 'status',
+        Value: ImageStatus.ACTIVE,
+      });
     });
 
     it('업로드된 이미지가 최적화 처리의 사양을 만족함', async () => {
@@ -85,6 +100,55 @@ describeWithDeps('StorageService', () => {
     it('이미지 업로드 성공 시 이미지 키가 올바른 형식으로 반환됨', async () => {
       const result = await service.uploadImage(imageData);
       expect(result.imageKey).toMatch(/^artworks\/\d{4}\/\d{2}\/[\w-]+\.webp$/);
+    });
+  });
+
+  describe('changeImageTag', () => {
+    let uploadedImageKey: string;
+
+    beforeEach(async () => {
+      const imageData = {
+        originalname: 'test.jpg',
+        mimetype: ImageFileType.JPEG,
+        buffer: await Sharp({
+          create: {
+            width: 100,
+            height: 100,
+            channels: 3,
+            background: 'blue',
+          },
+        })
+          .jpeg()
+          .toBuffer(),
+      } as Express.Multer.File;
+
+      const result = await service.uploadImage(imageData);
+      uploadedImageKey = result.imageKey;
+    });
+
+    it('이미지의 status 태그가 정상적으로 변경됨', async () => {
+      await service.changeImageTag(uploadedImageKey, ImageStatus.TO_DELETE);
+
+      const { TagSet } = await service.client.send(
+        new GetObjectTaggingCommand({
+          Bucket: TEST_S3_CONFIG.bucket,
+          Key: uploadedImageKey,
+        }),
+      );
+
+      expect(TagSet).toHaveLength(1);
+      expect(TagSet[0]).toEqual({
+        Key: 'status',
+        Value: ImageStatus.TO_DELETE,
+      });
+    });
+
+    it('존재하지 않는 이미지 키로 태그 변경 시 에러 발생', async () => {
+      const nonExistentKey = 'non-existent-key.webp';
+
+      await expect(
+        service.changeImageTag(nonExistentKey, ImageStatus.TO_DELETE),
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/cms-frontend/package.json
+++ b/packages/cms-frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@icons-pack/react-simple-icons": "^10.2.0",
-    "@minhoyunlife/my-ts-client": "1.4.0",
+    "@minhoyunlife/my-ts-client": "1.5.0",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/delete.tsx
+++ b/packages/cms-frontend/src/app/(authenticated)/genres/(actions)/delete.tsx
@@ -23,7 +23,7 @@ export function DeleteGenresDialog({
 
   const handleDelete = async () => {
     try {
-      await deleteGenresMutation.mutateAsync({ ids: selectedIds });
+      await deleteGenresMutation.mutateAsync({ ids: new Set(selectedIds) });
       toast({
         title: "장르가 삭제되었습니다",
         variant: "success",

--- a/packages/cms-frontend/src/hooks/genres/use-genres.ts
+++ b/packages/cms-frontend/src/hooks/genres/use-genres.ts
@@ -16,7 +16,7 @@ export interface GenreUpdateParams {
 }
 
 export interface GenreDeleteParams {
-  ids: string[];
+  ids: Set<string>;
 }
 
 export function useGenres() {
@@ -71,7 +71,7 @@ export function useGenres() {
   const useDelete = () =>
     useMutation({
       mutationFn: ({ ids }: GenreDeleteParams) =>
-        genresApi.deleteGenres(new Set(ids)),
+        genresApi.deleteGenres({ ids }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({ queryKey: ["genres"] });
       },

--- a/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/delete.test.tsx
+++ b/packages/cms-frontend/test/app/(authenticated)/genres/(actions)/delete.test.tsx
@@ -46,7 +46,7 @@ describe("DeleteGenresDialog", () => {
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
-        ids: defaultProps.selectedIds,
+        ids: new Set(defaultProps.selectedIds),
       });
       expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
       expect(defaultProps.onSuccess).toHaveBeenCalled();

--- a/packages/cms-frontend/test/hooks/genres/use-genres.test.tsx
+++ b/packages/cms-frontend/test/hooks/genres/use-genres.test.tsx
@@ -250,7 +250,7 @@ describe("useGenres", () => {
   });
 
   describe("useDelete", () => {
-    const mockIds = ["genre-1", "genre-2"];
+    const mockIds = new Set(["genre-1", "genre-2"]);
 
     beforeEach(() => {
       vi.clearAllMocks();
@@ -266,7 +266,7 @@ describe("useGenres", () => {
 
         await result.current.mutateAsync({ ids: mockIds });
 
-        expect(genresApi.deleteGenres).toHaveBeenCalledWith(new Set(mockIds));
+        expect(genresApi.deleteGenres).toHaveBeenCalledWith({ ids: mockIds });
       });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^10.2.0
         version: 10.2.0(react@18.2.0)
       '@minhoyunlife/my-ts-client':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.5.0
+        version: 1.5.0
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.4
         version: 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1025,8 +1025,8 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  '@minhoyunlife/my-ts-client@1.4.0':
-    resolution: {integrity: sha512-l8XfdPEL+ygUqhEbNdd4nGt0ez4uQum6Er5OCEJxMesXjmF839kbS3r/Iq4K/Dfb/+IM4cpR9MzjJDj4/w7b6A==, tarball: https://npm.pkg.github.com/download/@minhoyunlife/my-ts-client/1.4.0/9955a5af1fc1325a672564aec016618d37e11016}
+  '@minhoyunlife/my-ts-client@1.5.0':
+    resolution: {integrity: sha512-jSvZbLS+P+wNVgkz0Cgq/SnW1FLt6muRWEoBKw9SoNwP+su/EPb/oc09cLuLZ1fV/cxDvU65s1KD/Rr8bEIGqg==, tarball: https://npm.pkg.github.com/download/@minhoyunlife/my-ts-client/1.5.0/d3628fa5c7d733d30e80ac3c4463ee54b0091320}
 
   '@mole-inc/bin-wrapper@8.0.1':
     resolution: {integrity: sha512-sTGoeZnjI8N4KS+sW2AN95gDBErhAguvkw/tWdCjeM8bvxpz5lqrnd0vOJABA1A+Ic3zED7PYoLP/RANLgVotA==}
@@ -7076,7 +7076,7 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@minhoyunlife/my-ts-client@1.4.0':
+  '@minhoyunlife/my-ts-client@1.5.0':
     dependencies:
       axios: 1.7.8
     transitivePeerDependencies:


### PR DESCRIPTION
## 관련 이슈
close #49 

## 작업 내용
- 작품 이미지 업로드, 삭제 시 오브젝트에 알맞은 값으로 태깅하도록 수정
- 작품 삭제와 관련된 일련의 처리 구현
- aws 콘솔을 통해 라이프사이클 폴리시 설정(일단 1일로 설정 후, 향후 작품 삭제 시 원했던 대로 작동하는 경우 7일로 바꿀 것)
