### PR TITLE
feat(backend): enable graceful shutdown

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.738.0",
     "@aws-sdk/s3-request-presigner": "^3.738.0",
-    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.6",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.6",
@@ -32,7 +31,6 @@
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/passport-github2": "^1.2.9",
-    "axios": "^1.7.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,7 +1,15 @@
-import { Module, ValidationPipe } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  OnApplicationShutdown,
+  OnModuleInit,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APP_PIPE } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { DataSource } from 'typeorm';
 
 import { Environment } from '@/src/common/enums/environment.enum';
 import { ArtworksModule } from '@/src/modules/artworks/artworks.module';
@@ -12,6 +20,8 @@ import { GenresModule } from '@/src/modules/genres/genres.module';
 import { HealthModule } from '@/src/modules/health/health.module';
 import { SeedModule } from '@/src/modules/seed/seed.module';
 import { SeedService } from '@/src/modules/seed/seed.service';
+import { TerminationMiddleware } from '@/src/modules/termination/termination.middleware';
+import { TerminationService } from '@/src/modules/termination/termination.service';
 
 @Module({
   imports: [
@@ -25,6 +35,7 @@ import { SeedService } from '@/src/modules/seed/seed.service';
     GenresModule,
   ],
   providers: [
+    TerminationService,
     // 글로벌 밸리데이션 파이프는 모듈 외부에서 등록되면 의존성 주입이 불가능(예를 들어 main.ts)
     // main.ts 에서 주입 시, 일부 컨트롤러의 메소드에서 트랜스폼이 이뤄지지 않았으므로, 여기에 설정하여 앱 모듈이 임포트하는 전체 모듈에 적용되도록 함
     // https://docs.nestjs.com/pipes#global-scoped-pipes
@@ -36,10 +47,12 @@ import { SeedService } from '@/src/modules/seed/seed.service';
     },
   ],
 })
-export class AppModule {
+export class AppModule implements OnModuleInit, OnApplicationShutdown {
   constructor(
     private readonly configService: ConfigService,
     private readonly seedService: SeedService,
+    private readonly dataSource: DataSource,
+    private readonly terminationService: TerminationService,
   ) {}
 
   // 개발 환경용 시드 데이터 주입을 위해
@@ -54,5 +67,19 @@ export class AppModule {
         console.error('⛔️ Got errors while seeding data: ', error);
       }
     }
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    console.log(`🛑 Application shutdown initiated by (${signal})`);
+
+    await this.terminationService.initiateShutdown();
+    console.log('✅ All pending requests completed');
+
+    await this.dataSource.destroy();
+    console.log('✅ Database connections closed');
+  }
+
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(TerminationMiddleware).forRoutes('*');
   }
 }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -17,5 +17,7 @@ import { AppModule } from '@/src/app.module';
     credentials: true,
   });
 
+  app.enableShutdownHooks();
+
   await app.listen(configService.get('app').port);
 })();

--- a/packages/backend/src/modules/health/health.module.ts
+++ b/packages/backend/src/modules/health/health.module.ts
@@ -1,4 +1,3 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 
@@ -8,7 +7,10 @@ import { S3HealthIndicator } from '@/src/modules/health/indicators/s3.health.ind
 import { StorageModule } from '@/src/modules/storage/storage.module';
 
 @Module({
-  imports: [TerminusModule, HttpModule, StorageModule],
+  imports: [
+    TerminusModule.forRoot({ gracefulShutdownTimeoutMs: 3000 }),
+    StorageModule,
+  ],
   controllers: [HealthController],
   providers: [S3HealthIndicator, GithubHealthIndicator],
 })

--- a/packages/backend/src/modules/termination/termination.middleware.ts
+++ b/packages/backend/src/modules/termination/termination.middleware.ts
@@ -1,0 +1,26 @@
+import {
+  Injectable,
+  NestMiddleware,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+import type { Request, Response, NextFunction } from 'express';
+
+import { TerminationService } from '@/src/modules/termination/termination.service';
+
+@Injectable()
+export class TerminationMiddleware implements NestMiddleware {
+  constructor(private readonly terminationService: TerminationService) {}
+
+  use(_req: Request, res: Response, next: NextFunction) {
+    if (!this.terminationService.beginRequest()) {
+      throw new ServiceUnavailableException('Server is shutting down');
+    }
+
+    res.on('finish', () => {
+      this.terminationService.endRequest();
+    });
+
+    next();
+  }
+}

--- a/packages/backend/src/modules/termination/termination.service.ts
+++ b/packages/backend/src/modules/termination/termination.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TerminationService {
+  private isShuttingDown = false;
+  private activeRequests = 0;
+
+  get isTerminating() {
+    return this.isShuttingDown;
+  }
+
+  beginRequest() {
+    if (this.isShuttingDown) {
+      return false;
+    }
+    this.activeRequests++;
+    return true;
+  }
+
+  endRequest() {
+    this.activeRequests--;
+  }
+
+  async initiateShutdown() {
+    this.isShuttingDown = true;
+
+    while (this.activeRequests > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.738.0
         version: 3.738.0
-      '@nestjs/axios':
-        specifier: ^4.0.0
-        version: 4.0.0(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(axios@1.7.8)(rxjs@7.8.1)
       '@nestjs/common':
         specifier: ^11.0.6
         version: 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -46,9 +43,6 @@ importers:
       '@types/passport-github2':
         specifier: ^1.2.9
         version: 1.2.9
-      axios:
-        specifier: ^1.7.8
-        version: 1.7.8
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -7702,6 +7696,7 @@ snapshots:
       '@nestjs/common': 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       axios: 1.7.8
       rxjs: 7.8.1
+    optional: true
 
   '@nestjs/cli@11.0.2(@swc/cli@0.6.0(@swc/core@1.10.12(@swc/helpers@0.5.13))(chokidar@4.0.3))(@swc/core@1.10.12(@swc/helpers@0.5.13))(@types/node@22.12.0)':
     dependencies:


### PR DESCRIPTION
## 관련 이슈
close #63 

## 작업 내용
- #61 에서 readiness 관련 깃헙 체크의 방식을 tcp 를 통한 체크로 변경(rate limit 으로 인한 제한 우회)
- 그레이스풀 셧다운이 가능하도록 코드 수정
