### PR TITLE
fix: set base-ref input to change detection composite action

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,6 +1,11 @@
 name: Detect which packages are changed
 description: Detects changes and filter monorepo packages
 
+inputs:
+  base-ref:
+    description: Base reference to compare changes against
+    required: true
+
 outputs:
   packages:
     description: Changed packages list in JSON format
@@ -9,20 +14,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set base SHA
-      shell: bash
-      id: set-base-sha
-      run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-        else
-          echo "BASE_SHA=${{ github.event.before }}" >> $GITHUB_ENV
-        fi
     - name: Extract package names which are changed
       id: check-changes
       shell: bash
-      env:
-        GITHUB_BASE_SHA: ${{ env.BASE_SHA }}
       run: |
         chmod +x .github/actions/detect-changes/script.sh
-        .github/actions/detect-changes/script.sh
+        .github/actions/detect-changes/script.sh ${{ inputs.base-ref }}

--- a/.github/actions/detect-changes/script.sh
+++ b/.github/actions/detect-changes/script.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-echo "GITHUB_BASE_SHA: $GITHUB_BASE_SHA"
-echo "Current HEAD: $(git rev-parse HEAD)"
-
-# 실제 변경된 파일 목록 확인
-echo "Changed files:"
-git diff --name-only $GITHUB_BASE_SHA..HEAD
+base_ref="$1"
+if [[ -z "$base_ref" ]]; then
+  echo "Base ref argument is required."
+  exit 1
+fi
 
 # 코드 변경사항이 발생한 패키지 이름만을 따로 추출해서 배열화
 function get_package_names_from_code_changes() {
-  git diff --name-only $GITHUB_BASE_SHA..HEAD | \
+  git diff --name-only "$base_ref"...HEAD | \
   grep "^packages/" | \
   cut -d'/' -f2 | \
   sort -u | \
@@ -18,7 +17,7 @@ function get_package_names_from_code_changes() {
 
 # 의존성 변경사항이 발생한 패키지 이름만을 따로 추출해서 배열화
 function get_package_names_from_deps_changes() {
-  pnpm list --filter="...[$GITHUB_BASE_SHA]" --json | \
+  pnpm list --filter="...[$base_ref]" --json | \
   jq '[.[] | select(.name != "my-projects") | .name | sub("^@my-projects/"; "")]'
 }
 
@@ -26,7 +25,7 @@ function get_package_names_from_deps_changes() {
 function merge() {
   local code_changes="$1"
   local lock_changes="$2"
-  echo "$code_changes" "$lock_changes" | jq -c -s "add | unique"
+  echo "$code_changes" "$lock_changes" | jq -s "add | unique"
 }
 
 # 메인 로직
@@ -34,5 +33,4 @@ code_changes=$(get_package_names_from_code_changes)
 lock_changes=$(get_package_names_from_deps_changes)
 all_changes=$(merge "$code_changes" "$lock_changes")
 
-echo "Changed packages are: $all_changes"
-echo "packages=$all_changes" >> $GITHUB_OUTPUT
+echo "packages=${all_changes}" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Detect which packages are changed
         id: check-changes
         uses: ./.github/actions/detect-changes
+        with:
+          base-ref: ${{ github.event.before }}
 
   build-packages:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Detect which packages are changed
         id: check-changes
         uses: ./.github/actions/detect-changes
+        with:
+          base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   verify-packages:
     needs: detect-changes


### PR DESCRIPTION
## 관련 이슈
close #73 

## 작업 내용
- 패키지 또는 코드 변경을 감지하는 컴포지트 액션에 비교 기준이 되는 대상 SHA ref 를 인수로 받게끔 변경
- CI/CD 워크플로우 수정
