### PR TITLE
fix(backend): may solve no cookie found problem

### DIFF
--- a/packages/backend/src/modules/auth/auth.controller.ts
+++ b/packages/backend/src/modules/auth/auth.controller.ts
@@ -31,10 +31,17 @@ import { AdminUser } from '@/src/modules/auth/interfaces/admin-user.interface';
 
 @Controller('auth')
 export class AuthController {
+  private readonly cookieDomain: string;
+
   constructor(
     private readonly authService: AuthService,
     private readonly configService: ConfigService,
-  ) {}
+  ) {
+    this.cookieDomain =
+      this.configService.get('app.env') === Environment.PROD
+        ? '.minhoyun.life'
+        : undefined;
+  }
 
   @Get('github')
   @UseGuards(GithubAuthGuard)
@@ -94,6 +101,7 @@ export class AuthController {
             ? 'none'
             : 'lax',
         secure: this.configService.get('app.env') === Environment.PROD,
+        domain: this.cookieDomain,
       });
     }
 
@@ -163,6 +171,7 @@ export class AuthController {
       sameSite:
         this.configService.get('app.env') === Environment.PROD ? 'none' : 'lax',
       maxAge: this.authService.TOKEN_EXPIRY[TokenType.REFRESH] * 1000,
+      domain: this.cookieDomain,
     });
   }
 
@@ -172,6 +181,7 @@ export class AuthController {
       secure: this.configService.get('app.env') === Environment.PROD,
       sameSite:
         this.configService.get('app.env') === Environment.PROD ? 'none' : 'lax',
+      domain: this.cookieDomain,
     });
   }
 
@@ -180,6 +190,7 @@ export class AuthController {
       secure: this.configService.get('app.env') === Environment.PROD,
       sameSite:
         this.configService.get('app.env') === Environment.PROD ? 'none' : 'lax',
+      domain: this.cookieDomain,
     });
   }
 
@@ -188,6 +199,7 @@ export class AuthController {
       secure: this.configService.get('app.env') === Environment.PROD,
       sameSite:
         this.configService.get('app.env') === Environment.PROD ? 'none' : 'lax',
+      domain: this.cookieDomain,
     });
   }
 }


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
현재 백엔드에서 쿠키의 domain 속성을 명시적으로 설정하지 않고 있었음.
이에 따라, 서브 도메인(CMS)이 상위 도메인(API)에서 설정한 쿠키를 저장이 불가능하여, 이를 해결하기 위해 명시적으로 domain 속성을 지정하도록 코드를 수정.
