### PR TITLE
fix(cd): make aws cloudfront domain as secret env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,7 @@ env:
   ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
   GITHUB_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
   NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+  AWS_CLOUDFRONT_DOMAIN: ${{ secrets.AWS_CLOUDFRONT_DOMAIN }}
 
 jobs:
   detect-changes:
@@ -75,6 +76,7 @@ jobs:
           docker build \
             --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
             --build-arg NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} \
+            --build-arg AWS_CLOUDFRONT_DOMAIN=${AWS_CLOUDFRONT_DOMAIN} \
             -f docker/${{ matrix.packages }}.prod.Dockerfile \
             -t $FULL_IMAGE_PATH .
           docker push $FULL_IMAGE_PATH

--- a/docker/cms-frontend.prod.Dockerfile
+++ b/docker/cms-frontend.prod.Dockerfile
@@ -14,6 +14,7 @@ RUN pnpm install --frozen-lockfile
 # 3. Build Stage
 FROM base AS build
 ARG NEXT_PUBLIC_API_URL
+ARG AWS_CLOUDFRONT_DOMAIN
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/cms-frontend/node_modules ./packages/cms-frontend/node_modules
 COPY packages/cms-frontend ./packages/cms-frontend


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- 클라우드프론트 도메인을 시크릿 환경변수화하여, CMS 프론트엔드의 빌드 시에 해당 환경변수가 주입되도록 수정
