### PR TITLE
fix(backend): refactor artwork modules following five lines of code rules

### DIFF
--- a/packages/backend/src/modules/artworks/artworks.controller.ts
+++ b/packages/backend/src/modules/artworks/artworks.controller.ts
@@ -86,9 +86,7 @@ export class ArtworksController {
     @Req() request: Request & { user?: AdminUser },
   ) {
     const isAuthenticated = !!request.user;
-
     const pageSize = isAuthenticated ? PAGE_SIZE.CMS : PAGE_SIZE.PUBLIC;
-
     const result = await this.artworksService.getArtworks(
       query,
       isAuthenticated,
@@ -134,8 +132,7 @@ export class ArtworksController {
   async updateArtworksStatuses(
     @Body() dto: UpdateArtworkStatusesDto,
   ): Promise<void> {
-    const { ids, setPublished } = dto;
-    await this.artworksService.updateStatuses(ids, setPublished);
+    await this.artworksService.updateStatuses(dto.ids, dto.setPublished);
   }
 
   @Patch('/:id')

--- a/packages/backend/src/modules/artworks/artworks.service.ts
+++ b/packages/backend/src/modules/artworks/artworks.service.ts
@@ -1,26 +1,26 @@
 import { Inject, Injectable } from '@nestjs/common';
 
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { EntityManager, In } from 'typeorm';
+import { EntityManager } from 'typeorm';
 import { Logger } from 'winston';
 
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { addErrorMessages } from '@/src/common/exceptions/base.exception';
 import { EntityList } from '@/src/common/interfaces/entity-list.interface';
-import { withRetry } from '@/src/common/utils/retry.util';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
 import { GetArtworksQueryDto } from '@/src/modules/artworks/dtos/get-artworks-query.dto';
 import { UpdateArtworkDto } from '@/src/modules/artworks/dtos/update-artwork.dto';
 import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
-import { SortType } from '@/src/modules/artworks/enums/sort-type.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
 import { StatusError } from '@/src/modules/artworks/enums/status-error.enum';
 import { Status } from '@/src/modules/artworks/enums/status.enum';
 import {
   ArtworkErrorCode,
   ArtworkException,
 } from '@/src/modules/artworks/exceptions/artworks.exception';
+import { ArtworkFilter } from '@/src/modules/artworks/interfaces/filter.interface';
 import { StatusValidator } from '@/src/modules/artworks/validators/artwork-status.validator';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
@@ -39,58 +39,13 @@ export class ArtworksService {
     @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
   ) {}
 
-  /**
-   * 작품 목록을 쿼리의 조건에 맞춰서 조회
-   *
-   * @param query 작품 목록을 조회하기 위한 쿼리 정보
-   * @param query.page 페이지 번호 (기본값: 1)
-   * @param query.sort 정렬 방식 (undefined: 최신순)
-   * @param query.platforms 플랫폼 필터 (빈 배열 또는 undefined: 모든 플랫폼)
-   * @param query.genres 장르명 필터 (빈 배열 또는 undefined: 모든 장르)
-   * @param query.search 제목 검색어
-   * @param query.status 상태 필터 (인증된 경우에만 적용)
-   *                     - 빈 배열 또는 undefined: 모든 상태
-   *                     - DRAFT: 비공개만
-   *                     - PUBLISHED: 공개만
-   *                     - DRAFT, PUBLISHED: 모든 상태
-   * @param isAuthenticated 인증 여부
-   *                       - true: CMS 접근 (페이지당 10개, 상태 필터 적용)
-   *                       - false: 일반 접근 (페이지당 20개, 공개 작품만 표시)
-   * @returns 작품 목록과 총 작품 수
-   */
   async getArtworks(
-    query: GetArtworksQueryDto,
+    dto: GetArtworksQueryDto,
     isAuthenticated: boolean,
   ): Promise<EntityList<Artwork>> {
-    const page = query.page ?? 1; // 페이지 번호(디폴트: 1)
-    const pageSize = isAuthenticated ? PAGE_SIZE.CMS : PAGE_SIZE.PUBLIC; // 페이지 당 표시 작품 수(CMS: 10, 팬아트: 20)
-    const sort = query.sort ?? SortType.CREATED_DESC; // 정렬 방식(디폴트: 작성일자 기준 최신순)
-    const platforms = query.platforms?.length ? query.platforms : undefined; // 플랫폼 필터(디폴트: 모든 플랫폼)
-    const genreIds = query.genreIds?.length ? query.genreIds : undefined;
-    const search = query.search ?? undefined; // 제목 검색어(디폴트: 없음)
-
-    // 작품 상태 필터
-    // - 비인증: 항상 공개된 작품만([false])
-    // - 인증 + status 미지정: 모든 상태([true, false])
-    // - 인증 + status 지정: 지정된 상태만 필터링
-    let statusFilter = isAuthenticated ? [true, false] : [false];
-    if (isAuthenticated && query.status?.length) {
-      statusFilter = Array.from(
-        new Set(query.status.map((status) => status === Status.DRAFT)),
-      );
-    }
-
-    const [items, totalCount] = await this.artworksRepository.getAllWithFilters(
-      {
-        page,
-        pageSize,
-        sort,
-        platforms,
-        genreIds,
-        search,
-        isDraftIn: statusFilter,
-      },
-    );
+    const filters = this.buildArtworkFilters(dto, isAuthenticated);
+    const [items, totalCount] =
+      await this.artworksRepository.getAllWithFilters(filters);
 
     return {
       items,
@@ -98,266 +53,335 @@ export class ArtworksService {
     };
   }
 
-  /**
-   * 새로운 작품을 생성
-   * @param dto 새로운 작품을 생성하기 위한 정보를 포함하는 DTO
-   * @returns 생성된 작품
-   */
   async createArtwork(dto: CreateArtworkDto): Promise<Artwork> {
     return this.entityManager.transaction(async (manager) => {
       const artworksTxRepo = this.artworksRepository.forTransaction(manager);
       const genresTxRepo = this.genresRepository.forTransaction(manager);
 
-      const genres = await genresTxRepo.findBy({
-        id: In(dto.genreIds),
-      });
-      if (genres.length !== dto.genreIds.length) {
-        const existingGenreIds = new Set(genres.map((genre) => genre.id));
-        const notExistingIds = dto.genreIds.filter(
-          (id) => !existingGenreIds.has(id),
-        );
-
-        throw new ArtworkException(
-          ArtworkErrorCode.NOT_EXISTING_GENRES_INCLUDED,
-          "Some of the provided genres don't exist in DB",
-          {
-            genreIds: notExistingIds,
-          },
-        );
-      }
-
-      const artwork: Partial<Artwork> = {
-        imageKey: dto.imageKey,
-        createdAt: dto.createdAt ? new Date(dto.createdAt) : null,
-        playedOn: dto.playedOn,
-        rating: dto.rating,
-        isDraft: true, // 작품 생성 시에는 무조건 초안 상태
-        isVertical: dto.isVertical,
-        genres: genres,
-        translations: [
-          {
-            language: Language.KO,
-            title: dto.koTitle,
-            shortReview: dto.koShortReview,
-          },
-          {
-            language: Language.EN,
-            title: dto.enTitle,
-            shortReview: dto.enShortReview,
-          },
-          {
-            language: Language.JA,
-            title: dto.jaTitle,
-            shortReview: dto.jaShortReview,
-          },
-        ] as ArtworkTranslation[],
-      };
+      const genres = await this.findAndValidateGenres(
+        genresTxRepo,
+        dto.genreIds,
+      );
+      const artwork = this.buildArtworkEntity(dto, genres);
 
       return await artworksTxRepo.createOne(artwork);
     });
   }
 
-  /**
-   * 작품을 수정
-   * @param id 수정할 작품의 ID
-   * @param dto 수정할 작품의 정보를 포함하는 DTO
-   * @returns 수정된 작품
-   */
   async updateArtwork(id: string, dto: UpdateArtworkDto): Promise<Artwork> {
-    if (Object.values(dto).every((value) => value === undefined)) {
-      throw new ArtworkException(
-        ArtworkErrorCode.NO_DATA_PROVIDED,
-        'At least one field must be provided to update artwork',
-        {
-          fields: ['At least one field is required to update artwork'],
-        },
-      );
-    }
+    this.assertAtLeastOneFieldProvided(dto);
 
     return this.entityManager.transaction(async (manager) => {
       const artworksTxRepo = this.artworksRepository.forTransaction(manager);
       const genresTxRepo = this.genresRepository.forTransaction(manager);
 
-      let genres: Genre[];
-      if (dto.genreIds) {
-        genres =
-          dto.genreIds.length > 0
-            ? await genresTxRepo.findByIds(dto.genreIds)
-            : [];
+      const genres = dto.genreIds
+        ? await this.findAndValidateGenres(genresTxRepo, dto.genreIds)
+        : undefined;
 
-        if (genres.length !== dto.genreIds.length) {
-          const existingGenreIds = new Set(genres.map((genre) => genre.id));
-          const notExistingIds = dto.genreIds.filter(
-            (id) => !existingGenreIds.has(id),
-          );
-
-          throw new ArtworkException(
-            ArtworkErrorCode.NOT_EXISTING_GENRES_INCLUDED,
-            "Some of the provided genres don't exist in DB",
-            {
-              genreIds: notExistingIds,
-            },
-          );
-        }
-      }
-
-      let translations: ArtworkTranslation[] = [];
-      if (dto.koTitle || dto.koShortReview) {
-        translations.push({
-          language: Language.KO,
-          ...(dto.koTitle && { title: dto.koTitle }),
-          ...((dto.koShortReview || dto.koShortReview === '') && {
-            shortReview: dto.koShortReview,
-          }),
-        } as ArtworkTranslation); // 부분 수정이므로, 불가피하게 타입 단언을 수행. 리포지토리 층에서 갱신 대상과 원본을 머지하기 때문에 괜찮다고 판단함.
-      }
-      if (dto.enTitle || dto.enShortReview) {
-        translations.push({
-          language: Language.EN,
-          ...(dto.enTitle && { title: dto.enTitle }),
-          ...((dto.enShortReview || dto.enShortReview === '') && {
-            shortReview: dto.enShortReview,
-          }),
-        } as ArtworkTranslation);
-      }
-      if (dto.jaTitle || dto.jaShortReview) {
-        translations.push({
-          language: Language.JA,
-          ...(dto.jaTitle && { title: dto.jaTitle }),
-          ...((dto.jaShortReview || dto.jaShortReview === '') && {
-            shortReview: dto.jaShortReview,
-          }),
-        } as ArtworkTranslation);
-      }
-
-      const artworkData: Partial<Artwork> = {
+      const translations = this.buildTranslations(dto);
+      const artworkData = this.buildArtworkUpdateData(
         id,
-        ...(translations.length > 0 && { translations }),
-        ...(dto.genreIds && { genres }),
-        ...(dto.createdAt && { createdAt: new Date(dto.createdAt) }),
-        ...(dto.playedOn && { playedOn: dto.playedOn }),
-        ...(dto.rating !== undefined && { rating: dto.rating }),
-      };
+        dto,
+        translations,
+        genres,
+      );
 
       return artworksTxRepo.updateOne(artworkData);
     });
   }
 
-  /**
-   * 작품의 상태를 변경
-   * @param ids 상태를 변경할 작품의 ID
-   * @param setPublished 변경할 상태 값
-   */
   async updateStatuses(ids: string[], setPublished: boolean): Promise<void> {
-    const errorsByCode: Record<string, string[]> = {};
-    const validationFailedIds = new Set<string>();
-
     const artworks = await this.artworksRepository.findManyWithDetails(ids);
-
-    const foundIds = new Set(artworks.map((artwork) => artwork.id));
-    ids.forEach((id) => {
-      if (!foundIds.has(id)) {
-        validationFailedIds.add(id);
-        addErrorMessages(errorsByCode, StatusError.NOT_FOUND, [`${id}|id`]);
-      }
-    });
-
-    const artworksToUpdate = artworks.filter(
-      (artwork) => artwork.isDraft === setPublished,
+    const { idsToUpdate, errors } = this.validateStatusChange(
+      ids,
+      artworks,
+      setPublished,
     );
 
-    if (setPublished) {
-      for (const artwork of artworksToUpdate) {
-        const validationErrors = this.statusValidator.validate(artwork);
+    await this.tryUpdateStatuses(idsToUpdate, setPublished, errors);
 
-        if (validationErrors.length > 0) {
-          validationFailedIds.add(artwork.id);
-
-          const formattedErrors = this.statusValidator.formatErrors(
-            artwork,
-            validationErrors,
-          );
-          Object.entries(formattedErrors).forEach(([code, messages]) => {
-            addErrorMessages(errorsByCode, code, messages);
-          });
-        }
-      }
-    }
-
-    const idsToUpdate = artworksToUpdate
-      .filter((artwork) => !validationFailedIds.has(artwork.id))
-      .map((artwork) => artwork.id);
-
-    if (idsToUpdate.length > 0) {
-      try {
-        await this.artworksRepository.updateManyStatuses(
-          idsToUpdate,
-          setPublished,
-        );
-      } catch (error) {
-        idsToUpdate.forEach((id) => {
-          validationFailedIds.add(id);
-          addErrorMessages(errorsByCode, StatusError.UNKNOWN_FAILURE, [
-            `${id}|status`,
-          ]);
-        });
-      }
-    }
-
-    if (Object.keys(errorsByCode).length > 0) {
-      throw new ArtworkException(
-        ArtworkErrorCode.SOME_FAILED,
-        'Some status changes failed',
-        errorsByCode,
-      );
-    }
+    this.assertNoErrorsExist(errors);
   }
 
-  /**
-   * 복수의 기존 작품을 삭제
-   * @param id - 삭제할 작품의 ID
-   */
   async deleteArtworks(ids: string[]): Promise<void> {
     return this.entityManager.transaction(async (manager) => {
       const artworksTxRepo = this.artworksRepository.forTransaction(manager);
       const deletedArtworks = await artworksTxRepo.deleteMany(ids);
 
-      await Promise.all(
-        deletedArtworks.map(async (artwork) => {
-          try {
-            await withRetry(
-              () =>
-                this.storageService.changeImageTag(
-                  artwork.imageKey,
-                  ImageStatus.TO_DELETE,
-                ),
-              {
-                onError: (error, attempt) => {
-                  this.logger.warn('Failed to change image tag', {
-                    context: 'ArtworksService',
-                    metadata: {
-                      artworkId: artwork.id,
-                      imageKey: artwork.imageKey,
-                      attempt,
-                      error: error.message,
-                    },
-                  });
-                },
-              },
-            );
-          } catch (error) {
-            this.logger.error('Failed to change image tag after all retries', {
-              context: 'ArtworksService',
-              metadata: {
-                artworkId: artwork.id,
-                imageKey: artwork.imageKey,
-                error: error.message,
-                stack: error.stack,
-              },
-            });
-          }
-        }),
-      );
+      this.markArtworkAsDeleted(deletedArtworks);
     });
+  }
+
+  private buildArtworkFilters(
+    dto: GetArtworksQueryDto,
+    isAuthenticated: boolean,
+  ): ArtworkFilter {
+    return {
+      page: dto.page ?? 1,
+      pageSize: isAuthenticated ? PAGE_SIZE.CMS : PAGE_SIZE.PUBLIC,
+      sort: dto.sort ?? Sort.CREATED_DESC,
+      platforms: dto.platforms?.length ? dto.platforms : undefined,
+      genreIds: dto.genreIds?.length ? dto.genreIds : undefined,
+      search: dto.search ?? undefined,
+      isDraftIn: this.determineStatusFilter(dto.status, isAuthenticated),
+    };
+  }
+
+  private buildArtworkEntity(
+    dto: CreateArtworkDto,
+    genres: Genre[],
+  ): Partial<Artwork> {
+    return {
+      imageKey: dto.imageKey,
+      createdAt: dto.createdAt ? new Date(dto.createdAt) : null,
+      playedOn: dto.playedOn,
+      rating: dto.rating,
+      isDraft: true, // 작품 생성 시에는 무조건 초안 상태
+      isVertical: dto.isVertical,
+      genres: genres,
+      translations: [
+        {
+          language: Language.KO,
+          title: dto.koTitle,
+          shortReview: dto.koShortReview,
+        },
+        {
+          language: Language.EN,
+          title: dto.enTitle,
+          shortReview: dto.enShortReview,
+        },
+        {
+          language: Language.JA,
+          title: dto.jaTitle,
+          shortReview: dto.jaShortReview,
+        },
+      ] as ArtworkTranslation[],
+    };
+  }
+
+  private buildTranslations(dto: UpdateArtworkDto): ArtworkTranslation[] {
+    const translations: ArtworkTranslation[] = [];
+
+    this.addTranslationIfNeeded(
+      translations,
+      Language.KO,
+      dto.koTitle,
+      dto.koShortReview,
+    );
+    this.addTranslationIfNeeded(
+      translations,
+      Language.EN,
+      dto.enTitle,
+      dto.enShortReview,
+    );
+    this.addTranslationIfNeeded(
+      translations,
+      Language.JA,
+      dto.jaTitle,
+      dto.jaShortReview,
+    );
+
+    return translations;
+  }
+
+  private buildArtworkUpdateData(
+    id: string,
+    dto: UpdateArtworkDto,
+    translations: ArtworkTranslation[],
+    genres?: Genre[],
+  ): Partial<Artwork> {
+    return {
+      id,
+      ...(translations.length > 0 && { translations }),
+      ...(genres && { genres }),
+      ...(dto.createdAt && { createdAt: new Date(dto.createdAt) }),
+      ...(dto.playedOn !== undefined && { playedOn: dto.playedOn }),
+      ...(dto.rating !== undefined && { rating: dto.rating }),
+    };
+  }
+
+  private addTranslationIfNeeded(
+    translations: ArtworkTranslation[],
+    language: Language,
+    title?: string,
+    shortReview?: string,
+  ): void {
+    if (title === undefined && shortReview === undefined) return;
+
+    const translation = {
+      language,
+      ...(title !== undefined && { title }),
+      ...(shortReview !== undefined && { shortReview }),
+    } as ArtworkTranslation;
+
+    translations.push(translation);
+  }
+
+  private determineStatusFilter(
+    status: Status[] | undefined,
+    isAuthenticated: boolean,
+  ) {
+    if (!isAuthenticated) return [false];
+    return !status?.length
+      ? [true, false]
+      : Array.from(new Set(status.map((status) => status === Status.DRAFT)));
+  }
+
+  private async findAndValidateGenres(
+    genresRepo: GenresRepository,
+    genreIds: string[],
+  ): Promise<Genre[]> {
+    if (genreIds.length === 0) return [];
+
+    const genres = await genresRepo.findByIds(genreIds);
+    this.assertAllGenresExist(genres, genreIds);
+
+    return genres;
+  }
+
+  private validateStatusChange(
+    requestedIds: string[],
+    artworks: Artwork[],
+    setPublished: boolean,
+  ): { idsToUpdate: string[]; errors: Record<string, string[]> } {
+    const errors: Record<string, string[]> = {};
+    const invalidIds = new Set<string>();
+
+    this.detectMissingArtworkIds(requestedIds, artworks, invalidIds, errors);
+
+    const artworksToUpdate = artworks.filter(
+      (artwork) => artwork.isDraft === setPublished,
+    );
+
+    this.validateForPublishing(
+      setPublished,
+      artworksToUpdate,
+      invalidIds,
+      errors,
+    );
+
+    const idsToUpdate = artworksToUpdate
+      .filter((artwork) => !invalidIds.has(artwork.id))
+      .map((artwork) => artwork.id);
+
+    return { idsToUpdate, errors };
+  }
+
+  private detectMissingArtworkIds(
+    requestedIds: string[],
+    artworks: Artwork[],
+    invalidIds: Set<string>,
+    errors: Record<string, string[]>,
+  ): void {
+    const foundIds = new Set(artworks.map((artwork) => artwork.id));
+
+    for (const id of requestedIds) {
+      if (!foundIds.has(id)) {
+        invalidIds.add(id);
+        addErrorMessages(errors, StatusError.NOT_FOUND, [`${id}|id`]);
+      }
+    }
+  }
+
+  private validateForPublishing(
+    setPublished: boolean,
+    artworks: Artwork[],
+    invalidIds: Set<string>,
+    errors: Record<string, string[]>,
+  ): void {
+    if (!setPublished) return;
+
+    for (const artwork of artworks) {
+      const validationErrors = this.statusValidator.validate(artwork);
+
+      if (validationErrors.length > 0) {
+        invalidIds.add(artwork.id);
+
+        const formattedErrors = this.statusValidator.formatErrors(
+          artwork,
+          validationErrors,
+        );
+
+        for (const [code, messages] of Object.entries(formattedErrors)) {
+          addErrorMessages(errors, code, messages);
+        }
+      }
+    }
+  }
+
+  private async tryUpdateStatuses(
+    ids: string[],
+    setPublished: boolean,
+    errors: Record<string, string[]>,
+  ): Promise<void> {
+    if (ids.length === 0) return;
+
+    try {
+      await this.artworksRepository.updateManyStatuses(ids, setPublished);
+    } catch (error) {
+      for (const id of ids) {
+        addErrorMessages(errors, StatusError.UNKNOWN_FAILURE, [`${id}|status`]);
+      }
+    }
+  }
+
+  private async markArtworkAsDeleted(artworks: Artwork[]): Promise<void> {
+    await Promise.all(
+      artworks.map(async (artwork) => {
+        try {
+          await this.storageService.changeImageTag(
+            artwork.imageKey,
+            ImageStatus.TO_DELETE,
+          );
+        } catch (error) {
+          this.logger.error('Failed to change image tag after all retries', {
+            context: 'ArtworksService',
+            metadata: {
+              artworkId: artwork.id,
+              imageKey: artwork.imageKey,
+              error: error.message,
+              stack: error.stack,
+            },
+          });
+        }
+      }),
+    );
+  }
+
+  private assertAllGenresExist(genres: Genre[], genreIds: string[]): void {
+    if (genres.length === genreIds.length) return;
+
+    throw new ArtworkException(
+      ArtworkErrorCode.NOT_EXISTING_GENRES_INCLUDED,
+      "Some of the provided genres don't exist in DB",
+      {
+        genreIds: genreIds.filter(
+          (id) => !new Set(genres.map((genre) => genre.id)).has(id),
+        ),
+      },
+    );
+  }
+
+  private assertAtLeastOneFieldProvided(dto: UpdateArtworkDto): void {
+    if (Object.values(dto).some((value) => value !== undefined)) return;
+
+    throw new ArtworkException(
+      ArtworkErrorCode.NO_DATA_PROVIDED,
+      'At least one field must be provided to update artwork',
+      {
+        fields: ['At least one field is required to update artwork'],
+      },
+    );
+  }
+
+  private assertNoErrorsExist(errors: Record<string, string[]>): void {
+    if (Object.keys(errors).length === 0) return;
+
+    throw new ArtworkException(
+      ArtworkErrorCode.SOME_FAILED,
+      'Some status changes failed',
+      errors,
+    );
   }
 }

--- a/packages/backend/src/modules/artworks/dtos/get-artworks-query.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/get-artworks-query.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsEnum, IsOptional } from 'class-validator';
+import { IsIn, IsOptional, IsString } from 'class-validator';
 
 import {
   ValidatedEnumArray,
@@ -8,7 +8,7 @@ import {
 import { ValidatedInt } from '@/src/common/decorators/validated-int.decorator';
 import { ValidatedString } from '@/src/common/decorators/validated-string.decorator';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
-import { SortType } from '@/src/modules/artworks/enums/sort-type.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
 import { Status } from '@/src/modules/artworks/enums/status.enum';
 
 export class GetArtworksQueryDto {
@@ -22,8 +22,11 @@ export class GetArtworksQueryDto {
   page?: number;
 
   @IsOptional()
-  @IsEnum(SortType)
-  sort?: SortType = SortType.CREATED_DESC;
+  @IsIn(Sort.all())
+  @Transform(({ value }) => {
+    return Sort.fromString(value);
+  })
+  sort?: Sort = Sort.CREATED_DESC;
 
   @ValidatedEnumArray(Platform, { optional: true })
   @Transform(({ value }) => {

--- a/packages/backend/src/modules/artworks/entities/artworks.entity.ts
+++ b/packages/backend/src/modules/artworks/entities/artworks.entity.ts
@@ -57,9 +57,6 @@ export class Artwork {
   })
   rating: number;
 
-  // TODO: 프론트 구현 방식에 따라, 작품 이미지로부터 주요 색상들을 추출한 값을 저장할 칼럼을 추가할지도?
-  // colorPalette: string[];
-
   /**
    * 작품 공개 여부
    */

--- a/packages/backend/src/modules/artworks/enums/sort-type.enum.ts
+++ b/packages/backend/src/modules/artworks/enums/sort-type.enum.ts
@@ -1,9 +1,80 @@
-/**
- * 작품 정렬 열거형
- */
-export enum SortType {
-  CREATED_DESC = 'created_desc',
-  CREATED_ASC = 'created_asc',
-  RATING_DESC = 'rating_desc',
-  RATING_ASC = 'rating_asc',
+import { SelectQueryBuilder } from 'typeorm';
+
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
+
+interface SortStrategy {
+  readonly value: string;
+  apply(query: SelectQueryBuilder<Artwork>): void;
+}
+
+class CreatedDescStrategy implements SortStrategy {
+  readonly value = 'created_desc';
+
+  apply(query: SelectQueryBuilder<Artwork>) {
+    query.orderBy('artwork.createdAt', 'DESC');
+  }
+}
+
+class CreatedAscStrategy implements SortStrategy {
+  readonly value = 'created_asc';
+
+  apply(query: SelectQueryBuilder<Artwork>): void {
+    query.orderBy('artwork.createdAt', 'ASC');
+  }
+}
+
+class RatingDescStrategy implements SortStrategy {
+  readonly value = 'rating_desc';
+
+  apply(query: SelectQueryBuilder<Artwork>): void {
+    query.orderBy('artwork.rating', 'DESC');
+  }
+}
+
+class RatingAscStrategy implements SortStrategy {
+  readonly value = 'rating_asc';
+
+  apply(query: SelectQueryBuilder<Artwork>): void {
+    query.orderBy('artwork.rating', 'ASC');
+  }
+}
+
+export class Sort {
+  private constructor(private readonly strategy: SortStrategy) {}
+
+  static readonly CREATED_DESC = new Sort(new CreatedDescStrategy());
+  static readonly CREATED_ASC = new Sort(new CreatedAscStrategy());
+  static readonly RATING_DESC = new Sort(new RatingDescStrategy());
+  static readonly RATING_ASC = new Sort(new RatingAscStrategy());
+
+  static fromString(value: string): Sort {
+    const sortMap: Record<string, Sort> = {
+      [Sort.CREATED_DESC.strategy.value]: Sort.CREATED_DESC,
+      [Sort.CREATED_ASC.strategy.value]: Sort.CREATED_ASC,
+      [Sort.RATING_DESC.strategy.value]: Sort.RATING_DESC,
+      [Sort.RATING_ASC.strategy.value]: Sort.RATING_ASC,
+    };
+    return sortMap[value] || Sort.CREATED_DESC;
+  }
+
+  static all(): Sort[] {
+    return [
+      Sort.CREATED_DESC,
+      Sort.CREATED_ASC,
+      Sort.RATING_DESC,
+      Sort.RATING_ASC,
+    ];
+  }
+
+  static allValues(): string[] {
+    return Sort.all().map((sort) => sort.strategy.value);
+  }
+
+  toString(): string {
+    return this.strategy.value;
+  }
+
+  apply(query: SelectQueryBuilder<Artwork>): void {
+    this.strategy.apply(query);
+  }
 }

--- a/packages/backend/src/modules/artworks/interfaces/filter.interface.ts
+++ b/packages/backend/src/modules/artworks/interfaces/filter.interface.ts
@@ -1,0 +1,12 @@
+import { Platform } from '@/src/modules/artworks/enums/platform.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
+
+export interface ArtworkFilter {
+  page: number;
+  pageSize: number;
+  sort: Sort;
+  platforms?: Platform[];
+  genreIds?: string[];
+  search?: string;
+  isDraftIn: boolean[];
+}

--- a/packages/backend/src/modules/genres/genres.service.ts
+++ b/packages/backend/src/modules/genres/genres.service.ts
@@ -45,7 +45,7 @@ export class GenresService {
   async createGenre(dto: CreateGenreDto): Promise<Genre> {
     return this.entityManager.transaction(async (manager) => {
       const genresTxRepo = this.genresRepository.forTransaction(manager);
-      const genreData = this.createGenreDataFromDto(dto, null);
+      const genreData = this.buildGenreDataFromDto(dto, null);
       return await genresTxRepo.createOne(genreData);
     });
   }
@@ -55,7 +55,7 @@ export class GenresService {
 
     return this.entityManager.transaction(async (manager) => {
       const genresTxRepo = this.genresRepository.forTransaction(manager);
-      const genreData = this.createGenreDataFromDto(dto, id);
+      const genreData = this.buildGenreDataFromDto(dto, id);
       return await genresTxRepo.updateOne(genreData);
     });
   }
@@ -67,17 +67,17 @@ export class GenresService {
     });
   }
 
-  private createGenreDataFromDto(
+  private buildGenreDataFromDto(
     dto: UpdateGenreDto,
     id?: string,
   ): Partial<Genre> {
     return {
       id: id ? id : undefined,
-      translations: this.createTranslationsFromDto(dto),
+      translations: this.buildTranslationsFromDto(dto),
     };
   }
 
-  private createTranslationsFromDto(dto: UpdateGenreDto): GenreTranslation[] {
+  private buildTranslationsFromDto(dto: UpdateGenreDto): GenreTranslation[] {
     const translations = [];
     this.addTranslationIfProvided(translations, Language.KO, dto.koName);
     this.addTranslationIfProvided(translations, Language.EN, dto.enName);

--- a/packages/backend/test/modules/artworks/artworks.controller.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.controller.spec.ts
@@ -15,7 +15,7 @@ import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-tran
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { ImageFileType } from '@/src/modules/artworks/enums/file-type.enum';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
-import { SortType } from '@/src/modules/artworks/enums/sort-type.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
 import { StatusValidator } from '@/src/modules/artworks/validators/artwork-status.validator';
 import { AuthService } from '@/src/modules/auth/auth.service';
 import { Administrator } from '@/src/modules/auth/entities/administrator.entity';
@@ -228,7 +228,7 @@ describeWithDeps('ArtworksController', () => {
     it('정렬이 정상적으로 동작함', async () => {
       const response = await request(app.getHttpServer())
         .get('/artworks')
-        .query({ sort: SortType.CREATED_ASC })
+        .query({ sort: Sort.CREATED_ASC.toString() })
         .expect(200);
 
       await expect(response).toMatchOpenAPISpec();

--- a/packages/backend/test/modules/artworks/artworks.repository.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.repository.spec.ts
@@ -4,7 +4,7 @@ import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
-import { SortType } from '@/src/modules/artworks/enums/sort-type.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
 import { ArtworkException } from '@/src/modules/artworks/exceptions/artworks.exception';
 import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
@@ -283,7 +283,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [false],
         });
 
@@ -309,7 +309,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true],
         });
 
@@ -331,7 +331,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [false, true],
         });
 
@@ -345,7 +345,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           search: 'Zelda',
         });
@@ -361,7 +361,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           search: 'Final',
         });
@@ -383,7 +383,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -397,7 +397,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           platforms: [Platform.STEAM],
         });
@@ -422,7 +422,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           platforms: [Platform.STEAM, Platform.SWITCH],
         });
@@ -444,7 +444,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -458,7 +458,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           genreIds: [genres[0].id], // RPG
         });
@@ -489,7 +489,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           genreIds: [genres[0].id, genres[1].id], // RPG, Action
         });
@@ -516,7 +516,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -530,7 +530,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, _] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -552,7 +552,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, _] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.CREATED_ASC,
+          sort: Sort.CREATED_ASC,
           isDraftIn: [true, false],
         });
 
@@ -574,7 +574,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, _] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.RATING_DESC,
+          sort: Sort.RATING_DESC,
           isDraftIn: [true, false],
         });
 
@@ -596,7 +596,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, _] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 10,
-          sort: SortType.RATING_ASC,
+          sort: Sort.RATING_ASC,
           isDraftIn: [true, false],
         });
 
@@ -620,7 +620,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 2,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -641,7 +641,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 2, // 두번째 페이지
           pageSize: 2,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
         });
 
@@ -664,7 +664,7 @@ describeWithDeps('ArtworksRepository', () => {
         const [result, totalCount] = await artworkRepo.getAllWithFilters({
           page: 1,
           pageSize: 1,
-          sort: SortType.CREATED_DESC,
+          sort: Sort.CREATED_DESC,
           isDraftIn: [true, false],
           search: 'Final',
           platforms: [Platform.STEAM, Platform.EPIC],

--- a/packages/backend/test/modules/artworks/dtos/get-artworks-query.dto.spec.ts
+++ b/packages/backend/test/modules/artworks/dtos/get-artworks-query.dto.spec.ts
@@ -2,14 +2,14 @@ import { validate } from 'class-validator';
 
 import { GetArtworksQueryDto } from '@/src/modules/artworks/dtos/get-artworks-query.dto';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
-import { SortType } from '@/src/modules/artworks/enums/sort-type.enum';
+import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
 import { Status } from '@/src/modules/artworks/enums/status.enum';
 import { createDto } from '@/test/utils/dto.util';
 
 describeWithoutDeps('GetArtworksQueryDto', () => {
   const validDtoData: Partial<GetArtworksQueryDto> = {
     page: 1,
-    sort: SortType.CREATED_DESC,
+    sort: Sort.CREATED_DESC,
     platforms: [Platform.STEAM],
     genreIds: ['genre-1', 'genre-2'],
     search: 'test',
@@ -80,15 +80,14 @@ describeWithoutDeps('GetArtworksQueryDto', () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('값이 enum 에 존재하지 않는 경우, 에러가 발생함', async () => {
+    it('값이 enum 에 존재하지 않는 경우, 디폴트 값으로 설정됨', async () => {
       const dto = createDto(GetArtworksQueryDto, validDtoData, {
-        sort: 'unknown' as SortType,
+        sort: 'unknown' as unknown as Sort,
       });
       const errors = await validate(dto);
 
-      expect(errors).toHaveLength(1);
-      expect(errors[0].property).toBe('sort');
-      expect(errors[0].constraints).toHaveProperty('isEnum');
+      expect(errors).toHaveLength(0);
+      expect(dto.sort).toBe(Sort.CREATED_DESC);
     });
   });
 


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- 아트워크 모듈의 리팩터링
- 소트의 경우 enum 대신 전략 패턴 도입