### PR TITLE
fix(backend): delete winston cloudwatch log feature

### DIFF
--- a/packages/backend/src/modules/config/settings/logger.config.ts
+++ b/packages/backend/src/modules/config/settings/logger.config.ts
@@ -1,7 +1,6 @@
 import { registerAs } from '@nestjs/config';
 
 import * as winston from 'winston';
-import WinstonCloudwatch from 'winston-cloudwatch';
 
 export interface LogRequest {
   id: string;
@@ -96,15 +95,7 @@ export default registerAs('logger', () => {
               filename: 'logs/combined.log',
             }),
           ]
-        : [
-            new WinstonCloudwatch({
-              logGroupName: process.env.AWS_CLOUDWATCH_LOG_GROUP_NAME,
-              logStreamName: `backend-${new Date().toISOString().replace(/:/g, '-')}`,
-              awsRegion: process.env.AWS_REGION,
-              messageFormatter: ({ level, message, ...meta }) =>
-                JSON.stringify({ level, message, ...meta }),
-            }),
-          ]),
+        : []),
     ],
   };
 });


### PR DESCRIPTION
## 관련 이슈
- 

## 작업 내용
- 이미 ecs 단에서 클라우드 워치를 이용한 로깅을 수행 중이므로, 비용 절감을 위해 윈스턴 클라우드 워치 로깅을 중단
