### PR TITLE
fix(backend): separate entity-dto transformer methods from services by creating mapper classes 

### DIFF
--- a/packages/backend/src/common/interfaces/base.mapper.ts
+++ b/packages/backend/src/common/interfaces/base.mapper.ts
@@ -1,0 +1,4 @@
+export interface BaseMapper<Entity, CreateDto, UpdateDto> {
+  toEntityForCreate(createDto: CreateDto): Partial<Entity>;
+  toEntityForUpdate(updateDto: UpdateDto, id: string): Partial<Entity>;
+}

--- a/packages/backend/src/modules/artworks/artworks.controller.ts
+++ b/packages/backend/src/modules/artworks/artworks.controller.ts
@@ -20,8 +20,8 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { ArtworksService } from '@/src/modules/artworks/artworks.service';
 import {
-  ArtworkListResponse,
-  ArtworkResponse,
+  ArtworkListResponseDto,
+  ArtworkResponseDto,
 } from '@/src/modules/artworks/dtos/artwork-response.dto';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
 import { DeleteArtworksDto } from '@/src/modules/artworks/dtos/delete-artworks.dto';
@@ -92,7 +92,7 @@ export class ArtworksController {
       isAuthenticated,
     );
 
-    return new ArtworkListResponse(
+    return new ArtworkListResponseDto(
       this.storageService,
       result.items,
       result.totalCount,
@@ -106,9 +106,9 @@ export class ArtworksController {
   @HttpCode(HttpStatus.CREATED)
   async createArtwork(
     @Body() createArtworkDto: CreateArtworkDto,
-  ): Promise<ArtworkResponse> {
+  ): Promise<ArtworkResponseDto> {
     const artwork = await this.artworksService.createArtwork(createArtworkDto);
-    return new ArtworkResponse(this.storageService, artwork);
+    return new ArtworkResponseDto(this.storageService, artwork);
   }
 
   @Post('/images')
@@ -141,9 +141,9 @@ export class ArtworksController {
   async updateArtwork(
     @Param('id') id: string,
     @Body() dto: UpdateArtworkDto,
-  ): Promise<ArtworkResponse> {
+  ): Promise<ArtworkResponseDto> {
     const artwork = await this.artworksService.updateArtwork(id, dto);
-    return new ArtworkResponse(this.storageService, artwork);
+    return new ArtworkResponseDto(this.storageService, artwork);
   }
 
   @Delete()

--- a/packages/backend/src/modules/artworks/artworks.mapper.ts
+++ b/packages/backend/src/modules/artworks/artworks.mapper.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+
+import { BaseMapper } from '@/src/common/interfaces/base.mapper';
+import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
+import { UpdateArtworkDto } from '@/src/modules/artworks/dtos/update-artwork.dto';
+import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
+import { Language } from '@/src/modules/genres/enums/language.enum';
+
+@Injectable()
+export class ArtworksMapper
+  implements BaseMapper<Artwork, CreateArtworkDto, UpdateArtworkDto>
+{
+  toEntityForCreate(createDto: CreateArtworkDto): Partial<Artwork> {
+    return {
+      imageKey: createDto.imageKey,
+      createdAt: createDto.createdAt ? new Date(createDto.createdAt) : null,
+      playedOn: createDto.playedOn,
+      rating: createDto.rating,
+      isDraft: true,
+      isVertical: createDto.isVertical,
+      genres: [],
+      translations: [
+        {
+          language: Language.KO,
+          title: createDto.koTitle,
+          shortReview: createDto.koShortReview,
+        },
+        {
+          language: Language.EN,
+          title: createDto.enTitle,
+          shortReview: createDto.enShortReview,
+        },
+        {
+          language: Language.JA,
+          title: createDto.jaTitle,
+          shortReview: createDto.jaShortReview,
+        },
+      ] as ArtworkTranslation[],
+    };
+  }
+
+  toEntityForUpdate(updateDto: UpdateArtworkDto, id: string): Partial<Artwork> {
+    const translations = this.buildTranslations(updateDto);
+    return {
+      id,
+      ...(translations.length > 0 && { translations }),
+      ...(updateDto.createdAt && { createdAt: new Date(updateDto.createdAt) }),
+      ...(updateDto.playedOn !== undefined && { playedOn: updateDto.playedOn }),
+      ...(updateDto.rating !== undefined && { rating: updateDto.rating }),
+    };
+  }
+
+  private buildTranslations(dto: UpdateArtworkDto): ArtworkTranslation[] {
+    const translations: ArtworkTranslation[] = [];
+    this.addTranslationIfNeeded(
+      translations,
+      Language.KO,
+      dto.koTitle,
+      dto.koShortReview,
+    );
+    this.addTranslationIfNeeded(
+      translations,
+      Language.EN,
+      dto.enTitle,
+      dto.enShortReview,
+    );
+    this.addTranslationIfNeeded(
+      translations,
+      Language.JA,
+      dto.jaTitle,
+      dto.jaShortReview,
+    );
+
+    return translations;
+  }
+
+  private addTranslationIfNeeded(
+    translations: ArtworkTranslation[],
+    language: Language,
+    title?: string,
+    shortReview?: string,
+  ): void {
+    if (title === undefined && shortReview === undefined) return;
+
+    const translation = {
+      language,
+      ...(title !== undefined && { title }),
+      ...(shortReview !== undefined && { shortReview }),
+    } as ArtworkTranslation;
+
+    translations.push(translation);
+  }
+}

--- a/packages/backend/src/modules/artworks/artworks.module.ts
+++ b/packages/backend/src/modules/artworks/artworks.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ArtworksController } from '@/src/modules/artworks/artworks.controller';
+import { ArtworksMapper } from '@/src/modules/artworks/artworks.mapper';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { ArtworksService } from '@/src/modules/artworks/artworks.service';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
@@ -17,6 +18,7 @@ import { StorageService } from '@/src/modules/storage/storage.service';
   providers: [
     ArtworksRepository,
     ArtworksService,
+    ArtworksMapper,
     GenresRepository,
     StatusValidator,
     StorageService,

--- a/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
@@ -6,7 +6,7 @@ import { GenreResponseDto } from '@/src/modules/genres/dtos/genre-response.dto';
 import { StorageService } from '@/src/modules/storage/storage.service';
 
 @Injectable()
-export class ArtworkResponse {
+export class ArtworkResponseDto {
   id: string;
   imageUrl: string;
   createdAt: string;
@@ -32,8 +32,8 @@ export class ArtworkResponse {
 }
 
 @Injectable()
-export class ArtworkListResponse {
-  items: ArtworkResponse[];
+export class ArtworkListResponseDto {
+  items: ArtworkResponseDto[];
   metadata: {
     totalCount: number;
     totalPages: number;
@@ -49,7 +49,7 @@ export class ArtworkListResponse {
     pageSize: number,
   ) {
     this.items = artworks.map(
-      (artwork) => new ArtworkResponse(storageService, artwork),
+      (artwork) => new ArtworkResponseDto(storageService, artwork),
     );
     this.metadata = {
       totalCount,

--- a/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
-import { GenreResponse } from '@/src/modules/genres/dtos/genre-response.dto';
+import { GenreResponseDto } from '@/src/modules/genres/dtos/genre-response.dto';
 import { StorageService } from '@/src/modules/storage/storage.service';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class ArtworkResponse {
   isDraft: boolean;
   isVertical: boolean;
   translations: ArtworkTranslation[];
-  genres: GenreResponse[];
+  genres: GenreResponseDto[];
 
   constructor(storageService: StorageService, artwork: Artwork) {
     this.id = artwork.id;
@@ -27,7 +27,7 @@ export class ArtworkResponse {
     this.isVertical = artwork.isVertical;
     this.translations = artwork.translations ?? [];
     this.genres =
-      artwork.genres?.map((genre) => new GenreResponse(genre)) ?? [];
+      artwork.genres?.map((genre) => new GenreResponseDto(genre)) ?? [];
   }
 }
 

--- a/packages/backend/src/modules/genres/dtos/genre-response.dto.ts
+++ b/packages/backend/src/modules/genres/dtos/genre-response.dto.ts
@@ -4,7 +4,7 @@ import { GenreTranslation } from '@/src/modules/genres/interfaces/genre-translat
 /**
  * 단일 장르 응답용 DTO
  */
-export class GenreResponse {
+export class GenreResponseDto {
   id: string;
   translations: GenreTranslation[];
 
@@ -17,8 +17,8 @@ export class GenreResponse {
 /**
  * 페이지네이션을 포함한 장르 리스트 응답용 DTO
  */
-export class GenreListResponse {
-  items: GenreResponse[];
+export class GenreListResponseDto {
+  items: GenreResponseDto[];
   metadata: {
     totalCount: number;
     totalPages: number;
@@ -27,12 +27,12 @@ export class GenreListResponse {
   };
 
   constructor(
-    genres: Genre[],
+    items: GenreResponseDto[],
     totalCount: number,
     currentPage: number,
     pageSize: number,
   ) {
-    this.items = genres.map((genre) => new GenreResponse(genre));
+    this.items = items;
     this.metadata = {
       totalCount,
       totalPages: Math.ceil(totalCount / pageSize),
@@ -45,10 +45,10 @@ export class GenreListResponse {
 /**
  * 페이지네이션을 포함하지 않는, 장르 검색 결과 리스트 응답용 DTO
  */
-export class GenreSearchResponse {
-  items: GenreResponse[];
+export class GenreSearchResponseDto {
+  items: GenreResponseDto[];
 
-  constructor(genres: Genre[]) {
-    this.items = genres.map((genre) => new GenreResponse(genre));
+  constructor(items: GenreResponseDto[]) {
+    this.items = items;
   }
 }

--- a/packages/backend/src/modules/genres/genres.controller.ts
+++ b/packages/backend/src/modules/genres/genres.controller.ts
@@ -17,9 +17,9 @@ import { BearerAuthGuard } from '@/src/modules/auth/guards/token.auth.guard';
 import { CreateGenreDto } from '@/src/modules/genres/dtos/create-genre.dto';
 import { DeleteGenresDto } from '@/src/modules/genres/dtos/delete-genres.dto';
 import {
-  GenreListResponse,
-  GenreResponse,
-  GenreSearchResponse,
+  GenreListResponseDto,
+  GenreResponseDto,
+  GenreSearchResponseDto,
 } from '@/src/modules/genres/dtos/genre-response.dto';
 import { GetGenresByNameQueryDto } from '@/src/modules/genres/dtos/get-genres-by-name-query.dto';
 import { GetGenresQueryDto } from '@/src/modules/genres/dtos/get-genres-query.dto';
@@ -35,10 +35,10 @@ export class GenresController {
   @HttpCode(HttpStatus.OK)
   async getGenres(
     @Query() query: GetGenresQueryDto,
-  ): Promise<GenreListResponse> {
+  ): Promise<GenreListResponseDto> {
     const result = await this.genresService.getGenres(query);
 
-    return new GenreListResponse(
+    return new GenreListResponseDto(
       result.items,
       result.totalCount,
       query.page ?? 1,
@@ -52,15 +52,15 @@ export class GenresController {
   async getGenresByName(@Query() query: GetGenresByNameQueryDto) {
     const result = await this.genresService.getGenresByName(query);
 
-    return new GenreSearchResponse(result);
+    return new GenreSearchResponseDto(result);
   }
 
   @Post()
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.CREATED)
-  async createGenre(@Body() dto: CreateGenreDto): Promise<GenreResponse> {
+  async createGenre(@Body() dto: CreateGenreDto): Promise<GenreResponseDto> {
     const genre = await this.genresService.createGenre(dto);
-    return new GenreResponse(genre);
+    return new GenreResponseDto(genre);
   }
 
   @Patch('/:id')
@@ -69,9 +69,9 @@ export class GenresController {
   async updateGenre(
     @Param('id') id: string,
     @Body() dto: UpdateGenreDto,
-  ): Promise<GenreResponse> {
+  ): Promise<GenreResponseDto> {
     const genre = await this.genresService.updateGenre(id, dto);
-    return new GenreResponse(genre);
+    return new GenreResponseDto(genre);
   }
 
   @Delete()

--- a/packages/backend/src/modules/genres/genres.mapper.ts
+++ b/packages/backend/src/modules/genres/genres.mapper.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+
+import { BaseMapper } from '@/src/common/interfaces/base.mapper';
+import { CreateGenreDto } from '@/src/modules/genres/dtos/create-genre.dto';
+import { UpdateGenreDto } from '@/src/modules/genres/dtos/update-genre.dto';
+import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
+import { Genre } from '@/src/modules/genres/entities/genres.entity';
+import { Language } from '@/src/modules/genres/enums/language.enum';
+
+@Injectable()
+export class GenresMapper
+  implements BaseMapper<Genre, CreateGenreDto, UpdateGenreDto>
+{
+  toEntityForCreate(createDto: CreateGenreDto): Partial<Genre> {
+    return {
+      translations: [
+        { language: Language.KO, name: createDto.koName },
+        { language: Language.EN, name: createDto.enName },
+        { language: Language.JA, name: createDto.jaName },
+      ] as GenreTranslation[],
+    };
+  }
+
+  toEntityForUpdate(updateDto: UpdateGenreDto, id: string): Partial<Genre> {
+    const translations: GenreTranslation[] = [];
+    this.addTranslationIfNeeded(translations, Language.KO, updateDto.koName);
+    this.addTranslationIfNeeded(translations, Language.EN, updateDto.enName);
+    this.addTranslationIfNeeded(translations, Language.JA, updateDto.jaName);
+
+    return { id, translations };
+  }
+
+  private addTranslationIfNeeded(
+    translations: Partial<GenreTranslation>[],
+    language: Language,
+    name?: string,
+  ): void {
+    if (name === undefined) return;
+
+    translations.push({ language, name });
+  }
+}

--- a/packages/backend/src/modules/genres/genres.module.ts
+++ b/packages/backend/src/modules/genres/genres.module.ts
@@ -4,12 +4,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '@/src/modules/auth/auth.module';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { GenresController } from '@/src/modules/genres/genres.controller';
+import { GenresMapper } from '@/src/modules/genres/genres.mapper';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
 import { GenresService } from '@/src/modules/genres/genres.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Genre]), AuthModule],
   controllers: [GenresController],
-  providers: [GenresService, GenresRepository],
+  providers: [GenresService, GenresMapper, GenresRepository],
 })
 export class GenresModule {}

--- a/packages/backend/test/modules/artworks/artworks.controller.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.controller.spec.ts
@@ -6,6 +6,7 @@ import { DataSource, In, Repository } from 'typeorm';
 
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { ArtworksController } from '@/src/modules/artworks/artworks.controller';
+import { ArtworksMapper } from '@/src/modules/artworks/artworks.mapper';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { ArtworksService } from '@/src/modules/artworks/artworks.service';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
@@ -59,6 +60,7 @@ describeWithDeps('ArtworksController', () => {
         StorageService,
         ArtworksRepository,
         GenresRepository,
+        ArtworksMapper,
       ],
     });
 

--- a/packages/backend/test/modules/artworks/artworks.service.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.service.spec.ts
@@ -1,8 +1,7 @@
 import { TestingModule } from '@nestjs/testing';
 
-import { EntityManager, In } from 'typeorm';
-
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
+import { ArtworksMapper } from '@/src/modules/artworks/artworks.mapper';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { ArtworksService } from '@/src/modules/artworks/artworks.service';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
@@ -59,6 +58,7 @@ describeWithoutDeps('ArtworksService', () => {
             executeInTransaction: vi.fn((cb) => cb()),
           },
         },
+        ArtworksMapper,
       ],
     });
 

--- a/packages/backend/test/modules/artworks/dtos/artwork-response.dto.spec.ts
+++ b/packages/backend/test/modules/artworks/dtos/artwork-response.dto.spec.ts
@@ -5,7 +5,7 @@ import {
   ArtworkResponse,
 } from '@/src/modules/artworks/dtos/artwork-response.dto';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
-import { GenreResponse } from '@/src/modules/genres/dtos/genre-response.dto';
+import { GenreResponseDto } from '@/src/modules/genres/dtos/genre-response.dto';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { StorageService } from '@/src/modules/storage/storage.service';
@@ -136,9 +136,9 @@ describeWithoutDeps('ArtworkResponse', () => {
     });
 
     describe('genres', () => {
-      it('엔티티의 속성 값이 존재하는 경우, GenreResponse 인스턴스의 배열이 반환됨', () => {
+      it('엔티티의 속성 값이 존재하는 경우, GenreResponseDto 인스턴스의 배열이 반환됨', () => {
         expect(response.genres).toEqual(
-          genres.map((genre) => new GenreResponse(genre)),
+          genres.map((genre) => new GenreResponseDto(genre)),
         );
       });
 

--- a/packages/backend/test/modules/artworks/dtos/artwork-response.dto.spec.ts
+++ b/packages/backend/test/modules/artworks/dtos/artwork-response.dto.spec.ts
@@ -1,8 +1,6 @@
-import { ConfigService } from '@nestjs/config';
-
 import {
-  ArtworkListResponse,
-  ArtworkResponse,
+  ArtworkListResponseDto,
+  ArtworkResponseDto,
 } from '@/src/modules/artworks/dtos/artwork-response.dto';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { GenreResponseDto } from '@/src/modules/genres/dtos/genre-response.dto';
@@ -40,7 +38,7 @@ describeWithoutDeps('ArtworkResponse', () => {
   ) as Artwork;
 
   describe('ArtworkResponse', () => {
-    const response = new ArtworkResponse(mockStorageService, artwork);
+    const response = new ArtworkResponseDto(mockStorageService, artwork);
 
     it('엔티티의 속성 값대로 id 가 반환됨', () => {
       expect(response.id).toBe(artwork.id);
@@ -60,7 +58,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           createdAt: null,
         }) as Artwork;
 
-        const responseWithNullCreatedAt = new ArtworkResponse(
+        const responseWithNullCreatedAt = new ArtworkResponseDto(
           mockStorageService,
           artworkWithNullCreatedAt,
         );
@@ -79,7 +77,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           playedOn: null,
         }) as Artwork;
 
-        const responseWithNullPlayedOn = new ArtworkResponse(
+        const responseWithNullPlayedOn = new ArtworkResponseDto(
           mockStorageService,
           artworkWithNullPlayedOn,
         );
@@ -98,7 +96,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           rating: null,
         }) as Artwork;
 
-        const responseWithNullRating = new ArtworkResponse(
+        const responseWithNullRating = new ArtworkResponseDto(
           mockStorageService,
           artworkWithNullRating,
         );
@@ -126,7 +124,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           null,
         ) as Artwork;
 
-        const responseWithNullTranslations = new ArtworkResponse(
+        const responseWithNullTranslations = new ArtworkResponseDto(
           mockStorageService,
           artworkWithNullTranslations,
         );
@@ -147,7 +145,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           genres: undefined,
         }) as Artwork;
 
-        const responseWithUndefinedGenres = new ArtworkResponse(
+        const responseWithUndefinedGenres = new ArtworkResponseDto(
           mockStorageService,
           artworkWithUndefinedGenres,
         );
@@ -160,7 +158,7 @@ describeWithoutDeps('ArtworkResponse', () => {
           genres: [],
         }) as Artwork;
 
-        const responseWithEmptyGenres = new ArtworkResponse(
+        const responseWithEmptyGenres = new ArtworkResponseDto(
           mockStorageService,
           artworkWithEmptyGenres,
         );
@@ -172,7 +170,7 @@ describeWithoutDeps('ArtworkResponse', () => {
 
   describe('ArtworkListResponse', () => {
     const artworks = [artwork];
-    const response = new ArtworkListResponse(
+    const response = new ArtworkListResponseDto(
       mockStorageService,
       artworks,
       1,
@@ -183,7 +181,7 @@ describeWithoutDeps('ArtworkResponse', () => {
     it('엔티티의 속성 값대로 items 가 반환됨', () => {
       for (const a of artworks) {
         expect(response.items).toEqual([
-          new ArtworkResponse(mockStorageService, a),
+          new ArtworkResponseDto(mockStorageService, a),
         ]);
       }
     });

--- a/packages/backend/test/modules/genres/dtos/genre-response.dto.spec.ts
+++ b/packages/backend/test/modules/genres/dtos/genre-response.dto.spec.ts
@@ -1,7 +1,7 @@
 import {
-  GenreListResponse,
-  GenreResponse,
-  GenreSearchResponse,
+  GenreListResponseDto,
+  GenreResponseDto,
+  GenreSearchResponseDto,
 } from '@/src/modules/genres/dtos/genre-response.dto';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
@@ -25,7 +25,7 @@ describeWithoutDeps('GenreResponse', () => {
   ]) as Genre;
 
   describe('GenreResponse', () => {
-    const response = new GenreResponse(genre);
+    const response = new GenreResponseDto(genre);
 
     it('엔티티의 속성 값대로 id 가 반환됨', () => {
       expect(response.id).toBe(genre.id);
@@ -42,7 +42,7 @@ describeWithoutDeps('GenreResponse', () => {
           translations: null,
         }) as Genre;
 
-        const responseWithNullTranslations = new GenreResponse(
+        const responseWithNullTranslations = new GenreResponseDto(
           genreWithNullTranslations,
         );
 
@@ -54,11 +54,11 @@ describeWithoutDeps('GenreResponse', () => {
   describe('GenreListResponse', () => {
     const genres = [genre];
 
-    const response = new GenreListResponse(genres, 1, 1, 20);
+    const response = new GenreListResponseDto(genres, 1, 1, 20);
 
     it('엔티티의 속성 값대로 items 가 반환됨', () => {
       for (const g of genres) {
-        expect(response.items).toEqual([new GenreResponse(g)]);
+        expect(response.items).toEqual([new GenreResponseDto(g)]);
       }
     });
 
@@ -75,11 +75,11 @@ describeWithoutDeps('GenreResponse', () => {
   describe('GenreSearchResponse', () => {
     const genres = [genre];
 
-    const response = new GenreSearchResponse(genres);
+    const response = new GenreSearchResponseDto(genres);
 
     it('엔티티의 속성 값대로 items 가 반환됨', () => {
       for (const g of genres) {
-        expect(response.items).toEqual([new GenreResponse(g)]);
+        expect(response.items).toEqual([new GenreResponseDto(g)]);
       }
     });
   });

--- a/packages/backend/test/modules/genres/genres.controller.spec.ts
+++ b/packages/backend/test/modules/genres/genres.controller.spec.ts
@@ -18,6 +18,7 @@ import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { GenreErrorCode } from '@/src/modules/genres/exceptions/genres.exception';
 import { GenresController } from '@/src/modules/genres/genres.controller';
+import { GenresMapper } from '@/src/modules/genres/genres.mapper';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
 import { GenresService } from '@/src/modules/genres/genres.service';
 import { AdministratorsFactory } from '@/test/factories/administrator.factory';
@@ -49,7 +50,7 @@ describeWithDeps('GenresController', () => {
         Administrator,
       ],
       controllers: [GenresController],
-      providers: [GenresService, GenresRepository],
+      providers: [GenresService, GenresRepository, GenresMapper],
     });
 
     authService = app.get(AuthService);

--- a/packages/backend/test/modules/genres/genres.service.spec.ts
+++ b/packages/backend/test/modules/genres/genres.service.spec.ts
@@ -1,7 +1,5 @@
 import { TestingModule } from '@nestjs/testing';
 
-import { EntityManager } from 'typeorm';
-
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { CreateGenreDto } from '@/src/modules/genres/dtos/create-genre.dto';
 import { UpdateGenreDto } from '@/src/modules/genres/dtos/update-genre.dto';
@@ -10,6 +8,7 @@ import {
   GenreErrorCode,
   GenreException,
 } from '@/src/modules/genres/exceptions/genres.exception';
+import { GenresMapper } from '@/src/modules/genres/genres.mapper';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
 import { GenresService } from '@/src/modules/genres/genres.service';
 import { TransactionService } from '@/src/modules/transaction/transaction.service';
@@ -18,7 +17,6 @@ import { createTestingModuleWithoutDB } from '@/test/utils/module-builder.util';
 describeWithoutDeps('GenresService', () => {
   let service: GenresService;
   let genresRepository: Partial<GenresRepository>;
-  // let entityManager: EntityManager;
 
   beforeEach(async () => {
     const module: TestingModule = await createTestingModuleWithoutDB({
@@ -34,12 +32,12 @@ describeWithoutDeps('GenresService', () => {
             executeInTransaction: vi.fn((cb) => cb()),
           },
         },
+        GenresMapper,
       ],
     });
 
     service = module.get<GenresService>(GenresService);
     genresRepository = module.get<GenresRepository>(GenresRepository);
-    // entityManager = module.get<EntityManager>(EntityManager);
   });
 
   describe('getGenres', () => {


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
서비스 층에서 엔티티와 dto 사이의 상호 변환 처리를 프라이빗 메소드로 수행하고 있어 가독성과 역할의 모호함이 있던 기존 코드를, 대신 매퍼 클래스가 그 역할을 담당하도록 분리.
