### PR TITLE
feat(backend): define entities related to series

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { AppLoggerModule } from '@/src/modules/logger/logger.module';
 import { LoggingInterceptor } from '@/src/modules/logger/logging.interceptor';
 import { SeedModule } from '@/src/modules/seed/seed.module';
 import { SeedService } from '@/src/modules/seed/seed.service';
+import { SeriesModule } from '@/src/modules/series/series.module';
 import { TerminationMiddleware } from '@/src/modules/termination/termination.middleware';
 import { TerminationService } from '@/src/modules/termination/termination.service';
 import { TransactionModule } from '@/src/modules/transaction/transaction.module';
@@ -41,6 +42,7 @@ import { TransactionModule } from '@/src/modules/transaction/transaction.module'
     AuthModule,
     ArtworksModule,
     GenresModule,
+    SeriesModule,
   ],
   providers: [
     TerminationService,

--- a/packages/backend/src/migrations/1743239901401-addSeries.ts
+++ b/packages/backend/src/migrations/1743239901401-addSeries.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSeries1743239901401 implements MigrationInterface {
+  name = 'AddSeries1743239901401';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."series_translation_language_enum" AS ENUM('ko', 'en', 'ja')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "series_translation" ("seriesId" character varying NOT NULL, "language" "public"."series_translation_language_enum" NOT NULL, "title" character varying NOT NULL, CONSTRAINT "UQ_ef32ca93ebb92b0aaa0c014a7d1" UNIQUE ("title"), CONSTRAINT "PK_86e5831626c017f6a89d1eda2b3" PRIMARY KEY ("seriesId", "language"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_86e5831626c017f6a89d1eda2b" ON "series_translation" ("seriesId", "language") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "series" ("id" character varying(21) NOT NULL, CONSTRAINT "PK_e725676647382eb54540d7128ba" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e725676647382eb54540d7128b" ON "series" ("id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "series_artwork" ("seriesId" character varying NOT NULL, "artworkId" character varying NOT NULL, "order" integer NOT NULL DEFAULT '0', CONSTRAINT "PK_a4bab3b4a019282db7585b0e47e" PRIMARY KEY ("seriesId", "artworkId"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_a4bab3b4a019282db7585b0e47" ON "series_artwork" ("seriesId", "artworkId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "series_translation" ADD CONSTRAINT "FK_9e9033b773e835d2c4d5cac9507" FOREIGN KEY ("seriesId") REFERENCES "series"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "series_artwork" ADD CONSTRAINT "FK_fdc0841e57001801cf20b5c621e" FOREIGN KEY ("seriesId") REFERENCES "series"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "series_artwork" ADD CONSTRAINT "FK_7b4e001e809527685bdb11fcc3d" FOREIGN KEY ("artworkId") REFERENCES "artwork"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "series_artwork" DROP CONSTRAINT "FK_7b4e001e809527685bdb11fcc3d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "series_artwork" DROP CONSTRAINT "FK_fdc0841e57001801cf20b5c621e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "series_translation" DROP CONSTRAINT "FK_9e9033b773e835d2c4d5cac9507"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a4bab3b4a019282db7585b0e47"`,
+    );
+    await queryRunner.query(`DROP TABLE "series_artwork"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e725676647382eb54540d7128b"`,
+    );
+    await queryRunner.query(`DROP TABLE "series"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_86e5831626c017f6a89d1eda2b"`,
+    );
+    await queryRunner.query(`DROP TABLE "series_translation"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."series_translation_language_enum"`,
+    );
+  }
+}

--- a/packages/backend/src/modules/artworks/artworks.module.ts
+++ b/packages/backend/src/modules/artworks/artworks.module.ts
@@ -5,16 +5,26 @@ import { ArtworksController } from '@/src/modules/artworks/artworks.controller';
 import { ArtworksMapper } from '@/src/modules/artworks/artworks.mapper';
 import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
 import { ArtworksService } from '@/src/modules/artworks/artworks.service';
+import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { ArtworksValidator } from '@/src/modules/artworks/validators/artworks.validator';
 import { StatusValidator } from '@/src/modules/artworks/validators/status.validator';
 import { AuthModule } from '@/src/modules/auth/auth.module';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
 import { StorageService } from '@/src/modules/storage/storage.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Artwork, Genre]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([
+      Artwork,
+      ArtworkTranslation,
+      Genre,
+      SeriesArtwork,
+    ]),
+    AuthModule,
+  ],
   controllers: [ArtworksController],
   providers: [
     ArtworksRepository,

--- a/packages/backend/src/modules/artworks/entities/artworks.entity.ts
+++ b/packages/backend/src/modules/artworks/entities/artworks.entity.ts
@@ -6,12 +6,14 @@ import {
   JoinTable,
   ManyToMany,
   OneToMany,
+  type Relation,
 } from 'typeorm';
 
 import { NanoId } from '@/src/common/decorators/id.decorator';
 import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
 
 /**
  * 작품 정보를 DB에서 관리하기 위한 엔티티
@@ -74,7 +76,13 @@ export class Artwork {
    */
   @ManyToMany(() => Genre, (genre) => genre.artworks)
   @JoinTable()
-  genres: Genre[];
+  genres: Relation<Genre[]>;
+
+  /**
+   * 작품이 속한 시리즈 정보
+   */
+  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.artwork)
+  seriesArtworks: Relation<SeriesArtwork[]>;
 
   /**
    * 작품 정보를 다언어로 관리하기 위한 번역 정보
@@ -82,5 +90,5 @@ export class Artwork {
   @OneToMany(() => ArtworkTranslation, (translation) => translation.artwork, {
     cascade: true,
   })
-  translations: ArtworkTranslation[];
+  translations: Relation<ArtworkTranslation[]>;
 }

--- a/packages/backend/src/modules/genres/entities/genre-translations.entity.ts
+++ b/packages/backend/src/modules/genres/entities/genre-translations.entity.ts
@@ -5,9 +5,10 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryColumn,
+  type Relation,
 } from 'typeorm';
 
-import type { Genre } from '@/src/modules/genres/entities/genres.entity';
+import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 
 /**
@@ -37,9 +38,9 @@ export class GenreTranslation {
   /**
    * 관계
    */
-  @ManyToOne('Genre', (genre: Genre) => genre.translations, {
+  @ManyToOne(() => Genre, (genre: Genre) => genre.translations, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'genreId' })
-  genre: Genre;
+  genre: Relation<Genre>;
 }

--- a/packages/backend/src/modules/genres/entities/genres.entity.ts
+++ b/packages/backend/src/modules/genres/entities/genres.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Index, ManyToMany, OneToMany } from 'typeorm';
+import { Entity, Index, ManyToMany, OneToMany, type Relation } from 'typeorm';
 
 import { NanoId } from '@/src/common/decorators/id.decorator';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
@@ -20,7 +20,7 @@ export class Genre {
    * 장르를 참조하는 작품들
    */
   @ManyToMany(() => Artwork, (artwork) => artwork.genres)
-  artworks: Artwork[];
+  artworks: Relation<Artwork[]>;
 
   /**
    * 장르명을 다언어로 관리하기 위한 번역 정보
@@ -28,5 +28,5 @@ export class Genre {
   @OneToMany(() => GenreTranslation, (translation) => translation.genre, {
     cascade: true,
   })
-  translations: GenreTranslation[];
+  translations: Relation<GenreTranslation[]>;
 }

--- a/packages/backend/src/modules/genres/genres.module.ts
+++ b/packages/backend/src/modules/genres/genres.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '@/src/modules/auth/auth.module';
+import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { GenresController } from '@/src/modules/genres/genres.controller';
 import { GenresMapper } from '@/src/modules/genres/genres.mapper';
@@ -10,7 +11,7 @@ import { GenresService } from '@/src/modules/genres/genres.service';
 import { GenresValidator } from '@/src/modules/genres/genres.validator';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Genre]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Genre, GenreTranslation]), AuthModule],
   controllers: [GenresController],
   providers: [GenresService, GenresMapper, GenresValidator, GenresRepository],
 })

--- a/packages/backend/src/modules/seed/seed.module.ts
+++ b/packages/backend/src/modules/seed/seed.module.ts
@@ -7,6 +7,9 @@ import { Administrator } from '@/src/modules/auth/entities/administrator.entity'
 import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { SeedService } from '@/src/modules/seed/seed.service';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
+import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
+import { Series } from '@/src/modules/series/entities/series.entity';
 
 @Module({
   imports: [
@@ -16,6 +19,9 @@ import { SeedService } from '@/src/modules/seed/seed.service';
       Genre,
       GenreTranslation,
       Administrator,
+      Series,
+      SeriesTranslation,
+      SeriesArtwork,
     ]),
   ],
   providers: [SeedService],

--- a/packages/backend/src/modules/series/entities/series-artworks.entity.ts
+++ b/packages/backend/src/modules/series/entities/series-artworks.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  type Relation,
+} from 'typeorm';
+
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
+import { Series } from '@/src/modules/series/entities/series.entity';
+
+@Entity()
+@Index(['seriesId', 'artworkId'], { unique: true })
+export class SeriesArtwork {
+  /**
+   * 시리즈의 고유 ID
+   */
+  @PrimaryColumn()
+  seriesId: string;
+
+  /**
+   * 작품의 고유 ID
+   */
+  @PrimaryColumn()
+  artworkId: string;
+
+  /**
+   * 시리즈 내 작품 순서(0부터 시작)
+   */
+  @Column({ type: 'integer', default: 0 })
+  order: number;
+
+  /**
+   * 시리즈 관계
+   */
+  @ManyToOne(() => Series, (series: Series) => series.seriesArtworks, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'seriesId' })
+  series: Relation<Series>;
+
+  /**
+   * 작품 관계
+   */
+  @ManyToOne(() => Artwork, (artwork: Artwork) => artwork.seriesArtworks, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'artworkId' })
+  artwork: Relation<Artwork>;
+}

--- a/packages/backend/src/modules/series/entities/series-translations.entity.ts
+++ b/packages/backend/src/modules/series/entities/series-translations.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  type Relation,
+} from 'typeorm';
+
+import { Language } from '@/src/modules/genres/enums/language.enum';
+import { Series } from '@/src/modules/series/entities/series.entity';
+
+@Entity()
+@Index(['seriesId', 'language'], { unique: true })
+export class SeriesTranslation {
+  /**
+   * 시리즈의 고유 ID
+   */
+  @PrimaryColumn()
+  seriesId: string;
+
+  /**
+   * 시리즈의 언어 코드
+   */
+  @PrimaryColumn({ type: 'enum', enum: Language })
+  language: Language; // ISO 639-1 언어 코드(ko, en, ja 등)
+
+  /**
+   * 시리즈의 언어별 이름
+   */
+  @Column({ unique: true })
+  title: string;
+
+  /**
+   * 관계
+   */
+  @ManyToOne(() => Series, (series: Series) => series.translations, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'seriesId' })
+  series: Relation<Series>;
+}

--- a/packages/backend/src/modules/series/entities/series.entity.ts
+++ b/packages/backend/src/modules/series/entities/series.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Index, OneToMany, type Relation } from 'typeorm';
+
+import { NanoId } from '@/src/common/decorators/id.decorator';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
+import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
+
+@Entity()
+export class Series {
+  /**
+   * 시리즈의 고유 ID
+   */
+  @NanoId()
+  @Index()
+  id: string;
+
+  /**
+   * 시리즈에 포함된 작품들의 연결 정보
+   */
+  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.series)
+  seriesArtworks: Relation<SeriesArtwork[]>;
+
+  /**
+   * 시리즈 타이틀 이름을 다언어로 관리하기 위한 번역 정보
+   */
+  @OneToMany(() => SeriesTranslation, (translation) => translation.series, {
+    cascade: true,
+  })
+  translations: Relation<SeriesTranslation[]>;
+}

--- a/packages/backend/src/modules/series/series.controller.ts
+++ b/packages/backend/src/modules/series/series.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('series')
+export class SeriesController {}

--- a/packages/backend/src/modules/series/series.module.ts
+++ b/packages/backend/src/modules/series/series.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AuthModule } from '@/src/modules/auth/auth.module';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
+import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
+import { Series } from '@/src/modules/series/entities/series.entity';
+import { SeriesController } from '@/src/modules/series/series.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Series, SeriesTranslation, SeriesArtwork]),
+    AuthModule,
+  ],
+  controllers: [SeriesController],
+  providers: [],
+})
+export class SeriesModule {}

--- a/packages/backend/test/modules/artworks/artworks.controller.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.controller.spec.ts
@@ -12,7 +12,6 @@ import { ArtworksService } from '@/src/modules/artworks/artworks.service';
 import { CreateArtworkDto } from '@/src/modules/artworks/dtos/create-artwork.dto';
 import { UpdateArtworkStatusesDto } from '@/src/modules/artworks/dtos/update-artwork-statuses.dto';
 import { UpdateArtworkDto } from '@/src/modules/artworks/dtos/update-artwork.dto';
-import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { ImageFileType } from '@/src/modules/artworks/enums/file-type.enum';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
@@ -47,13 +46,7 @@ describeWithDeps('ArtworksController', () => {
 
   beforeAll(async () => {
     app = await createTestingApp({
-      entities: [
-        Artwork,
-        ArtworkTranslation,
-        Genre,
-        GenreTranslation,
-        Administrator,
-      ],
+      entities: [Artwork, Genre, Administrator],
       controllers: [ArtworksController],
       providers: [
         ArtworksService,

--- a/packages/backend/test/modules/artworks/artworks.repository.spec.ts
+++ b/packages/backend/test/modules/artworks/artworks.repository.spec.ts
@@ -5,7 +5,6 @@ import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-tran
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
 import { Sort } from '@/src/modules/artworks/enums/sort-type.enum';
-import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { GenresRepository } from '@/src/modules/genres/genres.repository';
@@ -24,7 +23,7 @@ describeWithDeps('ArtworksRepository', () => {
 
   beforeAll(async () => {
     const module = await createTestingModuleWithDB({
-      entities: [Artwork, ArtworkTranslation, Genre, GenreTranslation],
+      entities: [Artwork, ArtworkTranslation, Genre],
       providers: [ArtworksRepository, GenresRepository],
     });
 

--- a/packages/backend/test/modules/genres/genres.controller.spec.ts
+++ b/packages/backend/test/modules/genres/genres.controller.spec.ts
@@ -4,7 +4,6 @@ import request from 'supertest';
 import { DataSource, In, Repository } from 'typeorm';
 
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
-import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { AuthService } from '@/src/modules/auth/auth.service';
 import { Administrator } from '@/src/modules/auth/entities/administrator.entity';
@@ -43,13 +42,7 @@ describeWithDeps('GenresController', () => {
 
   beforeAll(async () => {
     app = await createTestingApp({
-      entities: [
-        Genre,
-        GenreTranslation,
-        Artwork,
-        ArtworkTranslation,
-        Administrator,
-      ],
+      entities: [Genre, GenreTranslation, Artwork, Administrator],
       controllers: [GenresController],
       providers: [
         GenresService,

--- a/packages/backend/test/modules/genres/genres.repository.spec.ts
+++ b/packages/backend/test/modules/genres/genres.repository.spec.ts
@@ -1,6 +1,5 @@
 import { DataSource, In, Repository } from 'typeorm';
 
-import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
@@ -21,7 +20,7 @@ describeWithDeps('GenresRepository', () => {
 
   beforeAll(async () => {
     const module = await createTestingModuleWithDB({
-      entities: [Genre, GenreTranslation, Artwork, ArtworkTranslation],
+      entities: [Genre, GenreTranslation, Artwork],
       providers: [GenresRepository],
     });
 

--- a/packages/backend/test/modules/transaction/transaction.service.spec.ts
+++ b/packages/backend/test/modules/transaction/transaction.service.spec.ts
@@ -1,16 +1,14 @@
 import { DataSource, Repository } from 'typeorm';
 
-import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { Platform } from '@/src/modules/artworks/enums/platform.enum';
-import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
 import { Genre } from '@/src/modules/genres/entities/genres.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { TransactionService } from '@/src/modules/transaction/transaction.service';
 import { ArtworkTranslationsFactory } from '@/test/factories/artwork-translations.factory';
 import { ArtworksFactory } from '@/test/factories/artworks.factory';
 import { GenresFactory } from '@/test/factories/genres.factory';
-import { clearTables, saveEntities } from '@/test/utils/database.util';
+import { clearTables } from '@/test/utils/database.util';
 import { createTestingModuleWithDB } from '@/test/utils/module-builder.util';
 
 describeWithDeps('TransactionService', () => {
@@ -21,7 +19,7 @@ describeWithDeps('TransactionService', () => {
 
   beforeAll(async () => {
     const module = await createTestingModuleWithDB({
-      entities: [Artwork, ArtworkTranslation, Genre, GenreTranslation],
+      entities: [Artwork, Genre],
       providers: [TransactionService],
     });
 

--- a/packages/backend/test/setups/deps.setup.ts
+++ b/packages/backend/test/setups/deps.setup.ts
@@ -68,7 +68,6 @@ async function initializeDatabase(retries = 3): Promise<DataSource> {
     try {
       const ds = new DataSource({
         ...TEST_DB_CONFIG,
-        // entities: [],
         synchronize: false, // 일단 셋업 단계에서는 동기화를 비활성화
       });
 

--- a/packages/backend/test/setups/deps.setup.ts
+++ b/packages/backend/test/setups/deps.setup.ts
@@ -68,7 +68,7 @@ async function initializeDatabase(retries = 3): Promise<DataSource> {
     try {
       const ds = new DataSource({
         ...TEST_DB_CONFIG,
-        entities: [],
+        // entities: [],
         synchronize: false, // 일단 셋업 단계에서는 동기화를 비활성화
       });
 

--- a/packages/backend/test/test.config.ts
+++ b/packages/backend/test/test.config.ts
@@ -1,3 +1,13 @@
+import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
+import { Administrator } from '@/src/modules/auth/entities/administrator.entity';
+import { Totp } from '@/src/modules/auth/entities/totp.entity';
+import { GenreTranslation } from '@/src/modules/genres/entities/genre-translations.entity';
+import { Genre } from '@/src/modules/genres/entities/genres.entity';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
+import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
+import { Series } from '@/src/modules/series/entities/series.entity';
+
 export const TEST_DB_CONFIG = {
   type: 'postgres' as const, // DataSourceOption 에서 리터럴 타입을 기대
   host: 'localhost',
@@ -5,7 +15,18 @@ export const TEST_DB_CONFIG = {
   username: 'postgres',
   password: 'password',
   database: 'test_db',
-  entities: ['../src/**/*.entity.ts'],
+  entities: [
+    // INFO: 엔티티가 추가될 때마다 여기에 추가할 것
+    Administrator,
+    Totp,
+    Artwork,
+    ArtworkTranslation,
+    Genre,
+    GenreTranslation,
+    Series,
+    SeriesTranslation,
+    SeriesArtwork,
+  ],
 };
 
 export const TEST_S3_CONFIG = {

--- a/packages/backend/test/utils/module-builder.util.ts
+++ b/packages/backend/test/utils/module-builder.util.ts
@@ -56,7 +56,6 @@ export async function createTestingModuleWithDB({
       testConfigModule,
       TypeOrmModule.forRoot({
         ...TEST_DB_CONFIG,
-        entities,
         synchronize: true,
       }),
       TypeOrmModule.forFeature(entities),
@@ -96,7 +95,6 @@ export async function createTestingApp({
       TransactionModule,
       TypeOrmModule.forRoot({
         ...TEST_DB_CONFIG,
-        entities,
         synchronize: true,
       }),
       TypeOrmModule.forFeature(entities),


### PR DESCRIPTION
## 관련 이슈
- #113 

## 작업 내용
- 시리즈 관련 엔티티 정의 및 아트워크 엔티티 수정
- 마이그레이션 파일 생성
- DB 의존 테스트에서 애초에 모든 엔티티의 테이블을 생성하도록 수정
