### PR TITLE
feat(backend): implement series deletion api

### DIFF
--- a/packages/backend/src/modules/artworks/entities/artworks.entity.ts
+++ b/packages/backend/src/modules/artworks/entities/artworks.entity.ts
@@ -81,7 +81,9 @@ export class Artwork {
   /**
    * 작품이 속한 시리즈 정보
    */
-  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.artwork)
+  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.artwork, {
+    cascade: true,
+  })
   seriesArtworks: Relation<SeriesArtwork[]>;
 
   /**

--- a/packages/backend/src/modules/genres/genres.validator.ts
+++ b/packages/backend/src/modules/genres/genres.validator.ts
@@ -61,13 +61,14 @@ export class GenresValidator {
   }
 
   assertGenresNotInUse(genres: Genre[]): void {
-    if (genres.every((g) => g.artworks.length === 0)) return;
+    const genresInUse = genres.filter((g) => g.artworks.length > 0);
+    if (genresInUse.length === 0) return;
 
     throw new GenreException(
       GenreErrorCode.IN_USE,
       'Some of the genres are in use by artworks',
       {
-        koNames: genres.map(
+        koNames: genresInUse.map(
           (g) => g.translations.find((t) => t.language === Language.KO)?.name,
         ),
       },

--- a/packages/backend/src/modules/series/dtos/delete-series.dto.ts
+++ b/packages/backend/src/modules/series/dtos/delete-series.dto.ts
@@ -1,0 +1,14 @@
+import { Transform } from 'class-transformer';
+
+import { ValidatedStringArray } from '@/src/common/decorators/validated-array.decorator';
+
+export class DeleteSeriesDto {
+  @ValidatedStringArray({ notEmpty: true })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return [value].filter(Boolean);
+    }
+    return Array.isArray(value) ? value.filter(Boolean) : value;
+  })
+  ids: string[];
+}

--- a/packages/backend/src/modules/series/entities/series.entity.ts
+++ b/packages/backend/src/modules/series/entities/series.entity.ts
@@ -16,7 +16,9 @@ export class Series {
   /**
    * 시리즈에 포함된 작품들의 연결 정보
    */
-  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.series)
+  @OneToMany(() => SeriesArtwork, (seriesArtwork) => seriesArtwork.series, {
+    cascade: true,
+  })
   seriesArtworks: Relation<SeriesArtwork[]>;
 
   /**

--- a/packages/backend/src/modules/series/series.controller.ts
+++ b/packages/backend/src/modules/series/series.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -12,6 +13,7 @@ import {
 import { PAGE_SIZE } from '@/src/common/constants/page-size.constant';
 import { BearerAuthGuard } from '@/src/modules/auth/guards/token.auth.guard';
 import { CreateSeriesDto } from '@/src/modules/series/dtos/create-series.dto';
+import { DeleteSeriesDto } from '@/src/modules/series/dtos/delete-series.dto';
 import { GetSeriesQueryDto } from '@/src/modules/series/dtos/get-series-query.dto';
 import {
   SeriesListResponseDto,
@@ -44,5 +46,12 @@ export class SeriesController {
   async createSeries(@Body() dto: CreateSeriesDto): Promise<SeriesResponseDto> {
     const series = await this.seriesService.createSeries(dto);
     return new SeriesResponseDto(series);
+  }
+
+  @Delete()
+  @UseGuards(BearerAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteSeries(@Body() dto: DeleteSeriesDto): Promise<void> {
+    await this.seriesService.deleteSeries(dto);
   }
 }

--- a/packages/backend/src/modules/series/series.exception.ts
+++ b/packages/backend/src/modules/series/series.exception.ts
@@ -5,11 +5,15 @@ import { BaseException } from '@/src/common/exceptions/base.exception';
 export enum SeriesErrorCode {
   NOT_ENOUGH_TRANSLATIONS = 'NOT_ENOUGH_TRANSLATIONS',
   DUPLICATE_TITLE = 'DUPLICATE_TITLE',
+  NOT_FOUND = 'NOT_FOUND',
+  IN_USE = 'IN_USE',
 }
 
 export const SERIES_ERROR_STATUS_MAP: Record<SeriesErrorCode, HttpStatus> = {
   [SeriesErrorCode.NOT_ENOUGH_TRANSLATIONS]: HttpStatus.BAD_REQUEST,
   [SeriesErrorCode.DUPLICATE_TITLE]: HttpStatus.CONFLICT,
+  [SeriesErrorCode.NOT_FOUND]: HttpStatus.NOT_FOUND,
+  [SeriesErrorCode.IN_USE]: HttpStatus.CONFLICT,
 };
 
 export class SeriesException extends BaseException {

--- a/packages/backend/src/modules/series/series.repository.ts
+++ b/packages/backend/src/modules/series/series.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { EntityManager, Repository, SelectQueryBuilder } from 'typeorm';
+import { EntityManager, In, Repository, SelectQueryBuilder } from 'typeorm';
 
 import { Transactional } from '@/src/common/interfaces/transactional.interface';
 import { Series } from '@/src/modules/series/entities/series.entity';
@@ -31,6 +31,15 @@ export class SeriesRepository implements Transactional<SeriesRepository> {
     return query.getManyAndCount();
   }
 
+  async findManyWithDetails(ids: string[]): Promise<Series[]> {
+    if (ids.length === 0) return [];
+
+    return this.repository.find({
+      where: { id: In(ids) },
+      relations: ['translations', 'seriesArtworks'],
+    });
+  }
+
   async findDuplicateTitleOfSeries(
     titles: string[],
     excludingId?: string,
@@ -42,6 +51,10 @@ export class SeriesRepository implements Transactional<SeriesRepository> {
 
   async createOne(seriesData: Partial<Series>): Promise<Series> {
     return this.repository.save(this.repository.create(seriesData));
+  }
+
+  async deleteMany(series: Series[]): Promise<void> {
+    await this.repository.remove(series);
   }
 
   private createBaseSeriesQuery(): SelectQueryBuilder<Series> {

--- a/packages/backend/src/modules/series/series.validator.ts
+++ b/packages/backend/src/modules/series/series.validator.ts
@@ -44,4 +44,31 @@ export class SeriesValidator {
       },
     );
   }
+
+  assertAllSeriesExist(series: Series[], ids: string[]): void {
+    if (series.length === ids.length) return;
+
+    throw new SeriesException(
+      SeriesErrorCode.NOT_FOUND,
+      'Some of the provided series do not exist',
+      {
+        ids: ids.filter((id) => !new Set(series.map((s) => s.id)).has(id)),
+      },
+    );
+  }
+
+  assertSeriesNotInUse(series: Series[]): void {
+    const seriesInUse = series.filter((s) => s.seriesArtworks.length > 0);
+    if (seriesInUse.length === 0) return;
+
+    throw new SeriesException(
+      SeriesErrorCode.IN_USE,
+      'Some of the series are in use by artworks',
+      {
+        koTitles: seriesInUse.map(
+          (s) => s.translations.find((t) => t.language === Language.KO)?.title,
+        ),
+      },
+    );
+  }
 }

--- a/packages/backend/test/modules/series/dtos/delete-series.dto.spec.ts
+++ b/packages/backend/test/modules/series/dtos/delete-series.dto.spec.ts
@@ -1,0 +1,60 @@
+import { validate } from 'class-validator';
+
+import { DeleteSeriesDto } from '@/src/modules/series/dtos/delete-series.dto';
+import { createDto } from '@/test/utils/dto.util';
+
+describeWithoutDeps('DeleteSeriesDto', () => {
+  const validDtoData: Partial<DeleteSeriesDto> = {
+    ids: ['series-1', 'series-2'],
+  };
+
+  describe('ids', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(DeleteSeriesDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('단일 값이 주어진 경우, 배열화됨', async () => {
+      const dto = createDto(DeleteSeriesDto, validDtoData, {
+        ids: 'series-1' as unknown as string[],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.ids).toEqual(['series-1']);
+    });
+
+    it('빈 배열이 주어진 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteSeriesDto, validDtoData, { ids: [] });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('arrayNotEmpty');
+    });
+
+    it('빈 값으로 주어진 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteSeriesDto, validDtoData, {
+        ids: ['', ''],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('arrayNotEmpty');
+    });
+
+    it('값이 생략된 경우, 에러가 발생함', async () => {
+      const dto = createDto(DeleteSeriesDto, validDtoData);
+      delete dto.ids;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('ids');
+      expect(errors[0].constraints).toHaveProperty('isArray');
+    });
+  });
+});

--- a/packages/backend/test/modules/series/series.validator.spec.ts
+++ b/packages/backend/test/modules/series/series.validator.spec.ts
@@ -1,4 +1,6 @@
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
 import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
 import { Series } from '@/src/modules/series/entities/series.entity';
 import {
@@ -6,6 +8,8 @@ import {
   SeriesException,
 } from '@/src/modules/series/series.exception';
 import { SeriesValidator } from '@/src/modules/series/series.validator';
+import { ArtworksFactory } from '@/test/factories/artworks.factory';
+import { SeriesArtworksFactory } from '@/test/factories/series-artworks.factory';
 import { SeriesFactory } from '@/test/factories/series.factory';
 
 describeWithoutDeps('SeriesValidator', () => {
@@ -78,6 +82,101 @@ describeWithoutDeps('SeriesValidator', () => {
         expect(e).toBeInstanceOf(SeriesException);
         expect(e.getCode()).toBe(SeriesErrorCode.DUPLICATE_TITLE);
         expect(e.getErrors()).toHaveProperty('titles');
+      }
+    });
+  });
+
+  describe('assertAllSeriesExist', () => {
+    it('모든 ID에 해당하는 시리즈가 존재하면 예외를 발생시키지 않음', () => {
+      const series = [
+        SeriesFactory.createTestData({ id: 'series-1' }),
+        SeriesFactory.createTestData({ id: 'series-2' }),
+      ];
+      const ids = ['series-1', 'series-2'];
+
+      expect(() =>
+        validator.assertAllSeriesExist(series as Series[], ids),
+      ).not.toThrow();
+    });
+
+    it('일부 ID에 해당하는 시리즈가 없으면 예외를 발생시킴', () => {
+      const series = [SeriesFactory.createTestData({ id: 'series-1' })];
+      const ids = ['series-1', 'non-existent'];
+
+      expect(() =>
+        validator.assertAllSeriesExist(series as Series[], ids),
+      ).toThrow(SeriesException);
+
+      try {
+        validator.assertAllSeriesExist(series as Series[], ids);
+      } catch (e) {
+        expect(e).toBeInstanceOf(SeriesException);
+        expect(e.getCode()).toBe(SeriesErrorCode.NOT_FOUND);
+        expect(e.getErrors()).toHaveProperty('ids');
+        expect(e.getErrors().ids).toContain('non-existent');
+      }
+    });
+  });
+
+  describe('assertSeriesNotInUse', () => {
+    it('모든 시리즈가 사용되지 않으면 예외를 발생시키지 않음', () => {
+      const series = [
+        SeriesFactory.createTestData({
+          id: 'series-1',
+          seriesArtworks: [],
+        }),
+        SeriesFactory.createTestData({
+          id: 'series-2',
+          seriesArtworks: [],
+        }),
+      ];
+
+      expect(() =>
+        validator.assertSeriesNotInUse(series as Series[]),
+      ).not.toThrow();
+    });
+
+    it('일부 시리즈가 작품에서 사용 중이면 예외를 발생시킴', () => {
+      const artwork = ArtworksFactory.createTestData({
+        id: 'artwork-1',
+      }) as Artwork;
+      const seriesWithTranslations = SeriesFactory.createTestData(
+        { id: 'series-2' },
+        [
+          { language: Language.KO, title: '시리즈 타이틀' },
+        ] as SeriesTranslation[],
+      );
+
+      const seriesArtwork = SeriesArtworksFactory.createTestData(
+        { order: 0 },
+        seriesWithTranslations as Series,
+        artwork,
+      ) as SeriesArtwork;
+
+      const seriesWithArtworks = {
+        ...seriesWithTranslations,
+        seriesArtworks: [seriesArtwork],
+      };
+
+      const series = [
+        SeriesFactory.createTestData({
+          id: 'series-1',
+          seriesArtworks: [],
+        }),
+        seriesWithArtworks,
+      ];
+
+      expect(() => validator.assertSeriesNotInUse(series as Series[])).toThrow(
+        SeriesException,
+      );
+
+      try {
+        validator.assertSeriesNotInUse(series as Series[]);
+      } catch (e) {
+        expect(e).toBeInstanceOf(SeriesException);
+        expect(e.getCode()).toBe(SeriesErrorCode.IN_USE);
+        expect(e.getErrors()).toHaveProperty('koTitles');
+        expect(e.getErrors().koTitles).toContain('시리즈 타이틀');
       }
     });
   });


### PR DESCRIPTION
## 관련 이슈
#113

## 작업 내용
- 시리즈 삭제 API 작성
- 장르 밸리데이터의 에러 메시지 성형용 메서드가 주어진 모든 장르명을 반환하는 것에서, 문제가 되는 장르명만 반환하도록 코드 수정