### PR TITLE
feat(backend): implement update series api

### DIFF
--- a/packages/backend/src/modules/artworks/artworks.controller.ts
+++ b/packages/backend/src/modules/artworks/artworks.controller.ts
@@ -111,7 +111,7 @@ export class ArtworksController {
     return new ArtworkResponseDto(this.storageService, artwork);
   }
 
-  @Post('/images')
+  @Post('images')
   @UseGuards(BearerAuthGuard)
   @UseFilters(UploadImageExceptionFilter)
   @UseInterceptors(FileInterceptor('image', ArtworksController.UPLOAD_OPTIONS))
@@ -126,7 +126,7 @@ export class ArtworksController {
     return this.storageService.uploadImage(image);
   }
 
-  @Patch('/statuses')
+  @Patch('statuses')
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateArtworksStatuses(
@@ -135,7 +135,7 @@ export class ArtworksController {
     await this.artworksService.updateStatuses(dto.ids, dto.setPublished);
   }
 
-  @Patch('/:id')
+  @Patch(':id')
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.OK)
   async updateArtwork(

--- a/packages/backend/src/modules/genres/genres.controller.ts
+++ b/packages/backend/src/modules/genres/genres.controller.ts
@@ -46,7 +46,7 @@ export class GenresController {
     );
   }
 
-  @Get('/names')
+  @Get('names')
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.OK)
   async getGenresByName(@Query() query: GetGenresByNameQueryDto) {
@@ -62,7 +62,7 @@ export class GenresController {
     return new GenreResponseDto(genre);
   }
 
-  @Patch('/:id')
+  @Patch(':id')
   @UseGuards(BearerAuthGuard)
   @HttpCode(HttpStatus.OK)
   async updateGenre(

--- a/packages/backend/src/modules/health/health.controller.ts
+++ b/packages/backend/src/modules/health/health.controller.ts
@@ -23,7 +23,7 @@ export class HealthController {
     private readonly github: GithubHealthIndicator,
   ) {}
 
-  @Get('/liveness')
+  @Get('liveness')
   @HealthCheck()
   check() {
     const config = this.configService.get('health');
@@ -44,7 +44,7 @@ export class HealthController {
     ]);
   }
 
-  @Get('/readiness')
+  @Get('readiness')
   @HealthCheck()
   async checkReadiness() {
     return this.health.check([

--- a/packages/backend/src/modules/series/dtos/update-series.dto.ts
+++ b/packages/backend/src/modules/series/dtos/update-series.dto.ts
@@ -1,2 +1,12 @@
-// TODO: 미구현 단계로, 시리즈 업데이트 구현 시 작업할 것.
-export class UpdateSeriesDto {}
+import { ValidatedString } from '@/src/common/decorators/validated-string.decorator';
+
+export class UpdateSeriesDto {
+  @ValidatedString({ optional: true, minLength: 1, maxLength: 100 })
+  koTitle?: string;
+
+  @ValidatedString({ optional: true, minLength: 1, maxLength: 100 })
+  enTitle?: string;
+
+  @ValidatedString({ optional: true, minLength: 1, maxLength: 100 })
+  jaTitle?: string;
+}

--- a/packages/backend/src/modules/series/series.controller.ts
+++ b/packages/backend/src/modules/series/series.controller.ts
@@ -5,6 +5,8 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -19,6 +21,7 @@ import {
   SeriesListResponseDto,
   SeriesResponseDto,
 } from '@/src/modules/series/dtos/series-response.dto';
+import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { SeriesService } from '@/src/modules/series/series.service';
 
 @Controller('series')
@@ -45,6 +48,17 @@ export class SeriesController {
   @HttpCode(HttpStatus.CREATED)
   async createSeries(@Body() dto: CreateSeriesDto): Promise<SeriesResponseDto> {
     const series = await this.seriesService.createSeries(dto);
+    return new SeriesResponseDto(series);
+  }
+
+  @Patch(':id')
+  @UseGuards(BearerAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async updateSeries(
+    @Param('id') id: string,
+    @Body() dto: UpdateSeriesDto,
+  ): Promise<SeriesResponseDto> {
+    const series = await this.seriesService.updateSeries(id, dto);
     return new SeriesResponseDto(series);
   }
 

--- a/packages/backend/src/modules/series/series.exception.ts
+++ b/packages/backend/src/modules/series/series.exception.ts
@@ -4,15 +4,17 @@ import { BaseException } from '@/src/common/exceptions/base.exception';
 
 export enum SeriesErrorCode {
   NOT_ENOUGH_TRANSLATIONS = 'NOT_ENOUGH_TRANSLATIONS',
-  DUPLICATE_TITLE = 'DUPLICATE_TITLE',
+  NO_TRANSLATIONS_PROVIDED = 'NO_TRANSLATIONS_PROVIDED',
   NOT_FOUND = 'NOT_FOUND',
+  DUPLICATE_TITLE = 'DUPLICATE_TITLE',
   IN_USE = 'IN_USE',
 }
 
 export const SERIES_ERROR_STATUS_MAP: Record<SeriesErrorCode, HttpStatus> = {
   [SeriesErrorCode.NOT_ENOUGH_TRANSLATIONS]: HttpStatus.BAD_REQUEST,
-  [SeriesErrorCode.DUPLICATE_TITLE]: HttpStatus.CONFLICT,
+  [SeriesErrorCode.NO_TRANSLATIONS_PROVIDED]: HttpStatus.BAD_REQUEST,
   [SeriesErrorCode.NOT_FOUND]: HttpStatus.NOT_FOUND,
+  [SeriesErrorCode.DUPLICATE_TITLE]: HttpStatus.CONFLICT,
   [SeriesErrorCode.IN_USE]: HttpStatus.CONFLICT,
 };
 

--- a/packages/backend/src/modules/series/series.mapper.ts
+++ b/packages/backend/src/modules/series/series.mapper.ts
@@ -22,8 +22,22 @@ export class SeriesMapper
     };
   }
 
-  // TODO: 미구현 단계로, 시리즈 업데이트 구현 시 작업할 것.
   toEntityForUpdate(updateDto: UpdateSeriesDto, id: string): Partial<Series> {
-    return {};
+    const translations: SeriesTranslation[] = [];
+    this.addTranslationIfNeeded(translations, Language.KO, updateDto.koTitle);
+    this.addTranslationIfNeeded(translations, Language.EN, updateDto.enTitle);
+    this.addTranslationIfNeeded(translations, Language.JA, updateDto.jaTitle);
+
+    return { id, translations };
+  }
+
+  private addTranslationIfNeeded(
+    translations: Partial<SeriesTranslation>[],
+    language: Language,
+    title?: string,
+  ): void {
+    if (title === undefined) return;
+
+    translations.push({ language, title });
   }
 }

--- a/packages/backend/src/modules/series/series.validator.ts
+++ b/packages/backend/src/modules/series/series.validator.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { Language } from '@/src/modules/genres/enums/language.enum';
+import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { Series } from '@/src/modules/series/entities/series.entity';
 import {
   SeriesErrorCode,
@@ -69,6 +70,27 @@ export class SeriesValidator {
           (s) => s.translations.find((t) => t.language === Language.KO)?.title,
         ),
       },
+    );
+  }
+
+  assertAtLeastOneTranslationTitleExist(dto: UpdateSeriesDto): void {
+    if (dto.koTitle || dto.enTitle || dto.jaTitle) return;
+
+    throw new SeriesException(
+      SeriesErrorCode.NO_TRANSLATIONS_PROVIDED,
+      'At least one translation must be provided',
+      {
+        translations: ['At least one translation is required to update series'],
+      },
+    );
+  }
+
+  assertSeriesExists(series: Series): void {
+    if (series) return;
+
+    throw new SeriesException(
+      SeriesErrorCode.NOT_FOUND,
+      'The series with the provided ID does not exist',
     );
   }
 }

--- a/packages/backend/test/modules/series/dtos/update-series.dto.spec.ts
+++ b/packages/backend/test/modules/series/dtos/update-series.dto.spec.ts
@@ -1,0 +1,155 @@
+import { validate } from 'class-validator';
+
+import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
+import { createDto } from '@/test/utils/dto.util';
+
+describeWithoutDeps('UpdateSeriesDto', () => {
+  const validDtoData: Partial<UpdateSeriesDto> = {
+    koTitle: '타이틀',
+    enTitle: 'title',
+    jaTitle: 'タイトル',
+  };
+
+  describe('koTitle', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 부적절한 화이트 스페이스의 구성으로 이뤄진 경우, 적절하게 조정함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        koTitle: '타이　틀',
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.koTitle).toBe('타이 틀');
+    });
+
+    it('키가 존재하지 않는 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      delete dto.koTitle;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 화이트 스페이스로만 이뤄진 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, { koTitle: '　' });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('koTitle');
+      expect(errors[0].constraints).toHaveProperty('minLength');
+    });
+
+    it('값이 일정 길이를 초과한 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        koTitle: 'a'.repeat(101),
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('koTitle');
+      expect(errors[0].constraints).toHaveProperty('maxLength');
+    });
+  });
+
+  describe('enTitle', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 부적절한 화이트 스페이스의 구성으로 이뤄진 경우, 적절하게 조정함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        enTitle: 'ti　tle',
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.enTitle).toBe('ti tle');
+    });
+
+    it('키가 존재하지 않는 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      delete dto.enTitle;
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 화이트 스페이스로만 이뤄진 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, { enTitle: '　' });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('enTitle');
+      expect(errors[0].constraints).toHaveProperty('minLength');
+    });
+
+    it('값이 일정 길이를 초과한 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        enTitle: 'a'.repeat(101),
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('enTitle');
+      expect(errors[0].constraints).toHaveProperty('maxLength');
+    });
+  });
+
+  describe('jaTitle', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 부적절한 화이트 스페이스의 구성으로 이뤄진 경우, 적절하게 조정함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        jaTitle: 'タイ　トル',
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.jaTitle).toBe('タイ トル');
+    });
+
+    it('키가 존재하지 않는 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData);
+      delete dto.jaTitle;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 화이트 스페이스로만 이뤄진 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, { jaTitle: '　' });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('jaTitle');
+      expect(errors[0].constraints).toHaveProperty('minLength');
+    });
+
+    it('값이 일정 길이를 초과한 경우, 에러가 발생함', async () => {
+      const dto = createDto(UpdateSeriesDto, validDtoData, {
+        jaTitle: 'a'.repeat(101),
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].property).toBe('jaTitle');
+      expect(errors[0].constraints).toHaveProperty('maxLength');
+    });
+  });
+});

--- a/packages/backend/test/modules/series/series.mapper.spec.ts
+++ b/packages/backend/test/modules/series/series.mapper.spec.ts
@@ -1,5 +1,6 @@
 import { Language } from '@/src/modules/genres/enums/language.enum';
 import { CreateSeriesDto } from '@/src/modules/series/dtos/create-series.dto';
+import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { SeriesMapper } from '@/src/modules/series/series.mapper';
 
 describeWithoutDeps('SeriesMapper', () => {
@@ -46,6 +47,107 @@ describeWithoutDeps('SeriesMapper', () => {
 
       expect(result).toHaveProperty('seriesArtworks');
       expect(result.seriesArtworks).toHaveLength(0);
+    });
+  });
+
+  describe('toEntityForUpdate', () => {
+    const seriesId = 'test-series-id';
+
+    it('모든 언어 번역이 있는 경우 모든 번역 데이터를 포함한 엔티티 데이터를 생성함', () => {
+      const updateDto: UpdateSeriesDto = {
+        koTitle: '수정된 타이틀',
+        enTitle: 'updated title',
+        jaTitle: '更新されたタイトル',
+      };
+
+      const result = mapper.toEntityForUpdate(updateDto, seriesId);
+
+      expect(result).toHaveProperty('id', seriesId);
+      expect(result).toHaveProperty('translations');
+      expect(result.translations).toHaveLength(3);
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.KO,
+          title: '수정된 타이틀',
+        }),
+      );
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.EN,
+          title: 'updated title',
+        }),
+      );
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.JA,
+          title: '更新されたタイトル',
+        }),
+      );
+    });
+
+    it('일부 언어 번역만 있는 경우 해당 번역 데이터만 포함한 엔티티 데이터를 생성함', () => {
+      const updateDto: UpdateSeriesDto = {
+        koTitle: '수정된 타이틀',
+        enTitle: 'updated title',
+      };
+
+      const result = mapper.toEntityForUpdate(updateDto, seriesId);
+
+      expect(result).toHaveProperty('id', seriesId);
+      expect(result).toHaveProperty('translations');
+      expect(result.translations).toHaveLength(2);
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.KO,
+          title: '수정된 타이틀',
+        }),
+      );
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.EN,
+          title: 'updated title',
+        }),
+      );
+      expect(result.translations).not.toContainEqual(
+        expect.objectContaining({
+          language: Language.JA,
+        }),
+      );
+    });
+
+    it('빈 언어 번역 필드의 경우 해당 번역 데이터를 포함하지 않음', () => {
+      const updateDto: UpdateSeriesDto = {
+        koTitle: '',
+        enTitle: 'updated title',
+      };
+
+      const result = mapper.toEntityForUpdate(updateDto, seriesId);
+
+      expect(result).toHaveProperty('id', seriesId);
+      expect(result).toHaveProperty('translations');
+      expect(result.translations).toHaveLength(2);
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.KO,
+          title: '',
+        }),
+      );
+      expect(result.translations).toContainEqual(
+        expect.objectContaining({
+          language: Language.EN,
+          title: 'updated title',
+        }),
+      );
+    });
+
+    it('번역 필드가 없는 경우 빈 번역 배열을 포함한 엔티티 데이터를 생성함', () => {
+      const updateDto: UpdateSeriesDto = {};
+
+      const result = mapper.toEntityForUpdate(updateDto, seriesId);
+
+      expect(result).toHaveProperty('id', seriesId);
+      expect(result).toHaveProperty('translations');
+      expect(result.translations).toHaveLength(0);
     });
   });
 });

--- a/packages/backend/test/modules/series/series.validator.spec.ts
+++ b/packages/backend/test/modules/series/series.validator.spec.ts
@@ -1,5 +1,6 @@
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { Language } from '@/src/modules/genres/enums/language.enum';
+import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
 import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
 import { Series } from '@/src/modules/series/entities/series.entity';
@@ -177,6 +178,48 @@ describeWithoutDeps('SeriesValidator', () => {
         expect(e.getCode()).toBe(SeriesErrorCode.IN_USE);
         expect(e.getErrors()).toHaveProperty('koTitles');
         expect(e.getErrors().koTitles).toContain('시리즈 타이틀');
+      }
+    });
+  });
+
+  describe('assertAtLeastOneTranslationTitleExist', () => {
+    it('적어도 하나의 번역이 있으면 예외를 발생시키지 않음', () => {
+      const dto = new UpdateSeriesDto();
+      dto.koTitle = '한국어 타이틀';
+
+      expect(() =>
+        validator.assertAtLeastOneTranslationTitleExist(dto),
+      ).not.toThrow();
+    });
+
+    it('번역이 하나도 없으면 예외를 발생시킴', () => {
+      const dto = new UpdateSeriesDto();
+
+      try {
+        validator.assertAtLeastOneTranslationTitleExist(dto);
+      } catch (e) {
+        expect(e).toBeInstanceOf(SeriesException);
+        expect(e.getCode()).toBe(SeriesErrorCode.NO_TRANSLATIONS_PROVIDED);
+        expect(e.getErrors()).toHaveProperty('translations');
+      }
+    });
+  });
+
+  describe('assertSeriesExists', () => {
+    it('시리즈가 존재하면 예외를 발생시키지 않음', () => {
+      const series = SeriesFactory.createTestData();
+
+      expect(() =>
+        validator.assertSeriesExists(series as Series),
+      ).not.toThrow();
+    });
+
+    it('시리즈가 존재하지 않으면 예외를 발생시킴', () => {
+      try {
+        validator.assertSeriesExists(null);
+      } catch (e) {
+        expect(e).toBeInstanceOf(SeriesException);
+        expect(e.getCode()).toBe(SeriesErrorCode.NOT_FOUND);
       }
     });
   });


### PR DESCRIPTION
## 관련 이슈
#113 

## 작업 내용
- 시리즈 수정(타이틀 수정) API 구현
- 기존 컨트롤러의 패스 명명의 앞 슬래시를 삭제
