### PR TITLE
feat(backend): implement updateSeriesArtwork api

### DIFF
--- a/packages/backend/src/modules/artworks/artworks.repository.ts
+++ b/packages/backend/src/modules/artworks/artworks.repository.ts
@@ -43,6 +43,8 @@ export class ArtworksRepository implements Transactional<ArtworksRepository> {
   }
 
   async findManyWithDetails(ids: string[]): Promise<Artwork[]> {
+    if (ids.length === 0) return [];
+
     return this.repository.find({
       where: { id: In(ids) },
       relations: ['translations', 'genres'],

--- a/packages/backend/src/modules/genres/genres.repository.ts
+++ b/packages/backend/src/modules/genres/genres.repository.ts
@@ -54,6 +54,8 @@ export class GenresRepository implements Transactional<GenresRepository> {
   }
 
   async findManyWithDetails(ids: string[]): Promise<Genre[]> {
+    if (ids.length === 0) return [];
+
     return this.repository.find({
       where: { id: In(ids) },
       relations: ['translations', 'artworks'],

--- a/packages/backend/src/modules/series/dtos/update-series-artworks.dto.ts
+++ b/packages/backend/src/modules/series/dtos/update-series-artworks.dto.ts
@@ -1,0 +1,19 @@
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+
+import { ValidatedInt } from '@/src/common/decorators/validated-int.decorator';
+import { ValidatedString } from '@/src/common/decorators/validated-string.decorator';
+
+export class SeriesArtworkItemDto {
+  @ValidatedString({ minLength: 1 })
+  id: string;
+
+  @ValidatedInt({ min: 0 })
+  order: number;
+}
+
+export class UpdateSeriesArtworksDto {
+  @ValidateNested({ each: true })
+  @Type(() => SeriesArtworkItemDto)
+  artworks: SeriesArtworkItemDto[];
+}

--- a/packages/backend/src/modules/series/series.controller.ts
+++ b/packages/backend/src/modules/series/series.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Put,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -21,6 +22,7 @@ import {
   SeriesListResponseDto,
   SeriesResponseDto,
 } from '@/src/modules/series/dtos/series-response.dto';
+import { UpdateSeriesArtworksDto } from '@/src/modules/series/dtos/update-series-artworks.dto';
 import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { SeriesService } from '@/src/modules/series/series.service';
 
@@ -59,6 +61,17 @@ export class SeriesController {
     @Body() dto: UpdateSeriesDto,
   ): Promise<SeriesResponseDto> {
     const series = await this.seriesService.updateSeries(id, dto);
+    return new SeriesResponseDto(series);
+  }
+
+  @Put(':id/artworks')
+  @UseGuards(BearerAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async updateSeriesArtwork(
+    @Param('id') id: string,
+    @Body() dto: UpdateSeriesArtworksDto,
+  ): Promise<SeriesResponseDto> {
+    const series = await this.seriesService.updateSeriesArtworks(id, dto);
     return new SeriesResponseDto(series);
   }
 

--- a/packages/backend/src/modules/series/series.module.ts
+++ b/packages/backend/src/modules/series/series.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ArtworksRepository } from '@/src/modules/artworks/artworks.repository';
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { AuthModule } from '@/src/modules/auth/auth.module';
 import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
 import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
@@ -13,10 +15,21 @@ import { SeriesValidator } from '@/src/modules/series/series.validator';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Series, SeriesTranslation, SeriesArtwork]),
+    TypeOrmModule.forFeature([
+      Series,
+      SeriesTranslation,
+      SeriesArtwork,
+      Artwork,
+    ]),
     AuthModule,
   ],
   controllers: [SeriesController],
-  providers: [SeriesService, SeriesMapper, SeriesValidator, SeriesRepository],
+  providers: [
+    SeriesService,
+    SeriesMapper,
+    SeriesValidator,
+    SeriesRepository,
+    ArtworksRepository,
+  ],
 })
 export class SeriesModule {}

--- a/packages/backend/src/modules/series/series.repository.ts
+++ b/packages/backend/src/modules/series/series.repository.ts
@@ -40,7 +40,7 @@ export class SeriesRepository implements Transactional<SeriesRepository> {
   async findOneWithDetails(id: string): Promise<Series> {
     return this.repository.findOne({
       where: { id },
-      relations: ['translations', 'seriesArtworks'],
+      relations: ['translations', 'seriesArtworks', 'seriesArtworks.artwork'],
     });
   }
 
@@ -49,7 +49,7 @@ export class SeriesRepository implements Transactional<SeriesRepository> {
 
     return this.repository.find({
       where: { id: In(ids) },
-      relations: ['translations', 'seriesArtworks'],
+      relations: ['translations', 'seriesArtworks', 'seriesArtworks.artwork'],
     });
   }
 

--- a/packages/backend/src/modules/series/series.validator.ts
+++ b/packages/backend/src/modules/series/series.validator.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { Language } from '@/src/common/enums/language.enum';
+import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { UpdateSeriesDto } from '@/src/modules/series/dtos/update-series.dto';
 import { Series } from '@/src/modules/series/entities/series.entity';
 import {
@@ -91,6 +92,18 @@ export class SeriesValidator {
     throw new SeriesException(
       SeriesErrorCode.NOT_FOUND,
       'The series with the provided ID does not exist',
+    );
+  }
+
+  assertAllArtworksExist(artworks: Artwork[], ids: string[]) {
+    if (artworks.length === ids.length) return;
+
+    throw new SeriesException(
+      SeriesErrorCode.NOT_FOUND,
+      'Some of the provided artworks do not exist',
+      {
+        ids: ids.filter((id) => !new Set(artworks.map((a) => a.id)).has(id)),
+      },
     );
   }
 }

--- a/packages/backend/test/modules/series/dtos/create-series.dto.spec.ts
+++ b/packages/backend/test/modules/series/dtos/create-series.dto.spec.ts
@@ -14,7 +14,6 @@ describeWithoutDeps('CreateSeriesDto', () => {
     it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
       const dto = createDto(CreateSeriesDto, validDtoData);
       const errors = await validate(dto);
-      console.log(errors);
 
       expect(errors).toHaveLength(0);
     });

--- a/packages/backend/test/modules/series/dtos/update-series-artworks.dto.spec.ts
+++ b/packages/backend/test/modules/series/dtos/update-series-artworks.dto.spec.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { UpdateSeriesArtworksDto } from '@/src/modules/series/dtos/update-series-artworks.dto';
+import { createDto } from '@/test/utils/dto.util';
+
+describeWithoutDeps('UpdateSeriesArtworksDto', () => {
+  const validDtoData: Partial<UpdateSeriesArtworksDto> = {
+    artworks: [
+      { id: 'artwork-1', order: 0 },
+      { id: 'artwork-2', order: 1 },
+      { id: 'artwork-3', order: 2 },
+    ],
+  };
+
+  describe('artworks', () => {
+    it('값이 유효한 경우, 에러가 발생하지 않음', async () => {
+      const dto = createDto(UpdateSeriesArtworksDto, validDtoData);
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('빈 배열도 유효함', async () => {
+      const dto = createDto(UpdateSeriesArtworksDto, {
+        artworks: [],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('값이 생략된 경우, 에러가 발생하지 않음 (빈 배열로 취급)', async () => {
+      const dto = new UpdateSeriesArtworksDto();
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.artworks).toBeUndefined();
+    });
+
+    describe('artworks 내부 항목 유효성 검증', () => {
+      it('작품 ID가 빈 문자열인 경우, 에러가 발생함', async () => {
+        const dto = plainToInstance(UpdateSeriesArtworksDto, {
+          artworks: [{ id: '', order: 0 }],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe('artworks');
+        expect(errors[0].children).toHaveLength(1);
+        expect(errors[0].children[0].property).toBe('0');
+        expect(errors[0].children[0].children).toHaveLength(1);
+        expect(errors[0].children[0].children[0].property).toBe('id');
+      });
+
+      it('작품 ID가 생략된 경우, 에러가 발생함', async () => {
+        const dto = plainToInstance(UpdateSeriesArtworksDto, {
+          artworks: [{ order: 0 }],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe('artworks');
+        expect(errors[0].children).toHaveLength(1);
+        expect(errors[0].children[0].property).toBe('0');
+        expect(errors[0].children[0].children).toHaveLength(1);
+        expect(errors[0].children[0].children[0].property).toBe('id');
+      });
+
+      it('order가 음수인 경우, 에러가 발생함', async () => {
+        const dto = plainToInstance(UpdateSeriesArtworksDto, {
+          artworks: [{ id: 'artwork-1', order: -1 }],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe('artworks');
+        expect(errors[0].children).toHaveLength(1);
+        expect(errors[0].children[0].property).toBe('0');
+        expect(errors[0].children[0].children).toHaveLength(1);
+        expect(errors[0].children[0].children[0].property).toBe('order');
+        expect(errors[0].children[0].children[0].constraints).toHaveProperty(
+          'min',
+        );
+      });
+
+      it('order가 정수가 아닌 경우, 에러가 발생함', async () => {
+        const dto = plainToInstance(UpdateSeriesArtworksDto, {
+          artworks: [{ id: 'artwork-1', order: 1.5 }],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe('artworks');
+        expect(errors[0].children).toHaveLength(1);
+        expect(errors[0].children[0].property).toBe('0');
+        expect(errors[0].children[0].children).toHaveLength(1);
+        expect(errors[0].children[0].children[0].property).toBe('order');
+        expect(errors[0].children[0].children[0].constraints).toHaveProperty(
+          'isInt',
+        );
+      });
+
+      it('order가 생략된 경우, 에러가 발생함', async () => {
+        const dto = plainToInstance(UpdateSeriesArtworksDto, {
+          artworks: [{ id: 'artwork-1' }],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe('artworks');
+        expect(errors[0].children).toHaveLength(1);
+        expect(errors[0].children[0].property).toBe('0');
+        expect(errors[0].children[0].children).toHaveLength(1);
+        expect(errors[0].children[0].children[0].property).toBe('order');
+        expect(errors[0].children[0].children[0].constraints).toHaveProperty(
+          'isInt',
+        );
+      });
+    });
+  });
+});

--- a/packages/backend/test/modules/series/series.validator.spec.ts
+++ b/packages/backend/test/modules/series/series.validator.spec.ts
@@ -223,4 +223,34 @@ describeWithoutDeps('SeriesValidator', () => {
       }
     });
   });
+
+  describe('assertAllArtworksExist', () => {
+    it('모든 아트워크가 존재하면 예외를 발생시키지 않음', () => {
+      const artworks = [
+        ArtworksFactory.createTestData({ id: 'artwork-1' }) as Artwork,
+        ArtworksFactory.createTestData({ id: 'artwork-2' }) as Artwork,
+      ];
+      const ids = ['artwork-1', 'artwork-2'];
+
+      expect(() =>
+        validator.assertAllArtworksExist(artworks, ids),
+      ).not.toThrow();
+    });
+
+    it('일부 아트워크가 존재하지 않으면 예외를 발생시킴', () => {
+      const artworks = [
+        ArtworksFactory.createTestData({ id: 'artwork-1' }) as Artwork,
+      ];
+      const ids = ['artwork-1', 'non-existent-artwork'];
+
+      try {
+        validator.assertAllArtworksExist(artworks, ids);
+      } catch (e) {
+        expect(e).toBeInstanceOf(SeriesException);
+        expect(e.getCode()).toBe(SeriesErrorCode.NOT_FOUND);
+        expect(e.getErrors()).toHaveProperty('ids');
+        expect(e.getErrors().ids).toContain('non-existent-artwork');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## 관련 이슈
#113 

## 작업 내용
- 시리즈와 아트워크간의 연결 테이블의 레코드를 PUT 하는 API 의 구현
