### PR TITLE
feat(backend): add series to artwork response

### DIFF
--- a/packages/backend/src/modules/artworks/artworks.repository.ts
+++ b/packages/backend/src/modules/artworks/artworks.repository.ts
@@ -38,7 +38,13 @@ export class ArtworksRepository implements Transactional<ArtworksRepository> {
   async findOneWithDetails(id: string): Promise<Artwork> {
     return this.repository.findOne({
       where: { id },
-      relations: ['translations', 'genres'],
+      relations: [
+        'translations',
+        'genres',
+        'seriesArtworks',
+        'seriesArtworks.series',
+        'seriesArtworks.series.translations',
+      ],
     });
   }
 
@@ -47,7 +53,13 @@ export class ArtworksRepository implements Transactional<ArtworksRepository> {
 
     return this.repository.find({
       where: { id: In(ids) },
-      relations: ['translations', 'genres'],
+      relations: [
+        'translations',
+        'genres',
+        'seriesArtworks',
+        'seriesArtworks.series',
+        'seriesArtworks.series.translations',
+      ],
     });
   }
 
@@ -82,7 +94,10 @@ export class ArtworksRepository implements Transactional<ArtworksRepository> {
       .createQueryBuilder('artwork')
       .leftJoinAndSelect('artwork.genres', 'genre')
       .leftJoinAndSelect('genre.translations', 'translation')
-      .leftJoinAndSelect('artwork.translations', 'artworkTranslation');
+      .leftJoinAndSelect('artwork.translations', 'artworkTranslation')
+      .leftJoinAndSelect('artwork.seriesArtworks', 'seriesArtwork')
+      .leftJoinAndSelect('seriesArtwork.series', 'series')
+      .leftJoinAndSelect('series.translations', 'seriesTranslation');
   }
 
   private applyGenreFilter(

--- a/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
@@ -1,11 +1,22 @@
-import { Injectable } from '@nestjs/common';
-
 import { ArtworkTranslation } from '@/src/modules/artworks/entities/artwork-translations.entity';
 import { Artwork } from '@/src/modules/artworks/entities/artworks.entity';
 import { GenreResponseDto } from '@/src/modules/genres/dtos/genre-response.dto';
+import { SeriesArtwork } from '@/src/modules/series/entities/series-artworks.entity';
+import { SeriesTranslation } from '@/src/modules/series/entities/series-translations.entity';
 import { StorageService } from '@/src/modules/storage/storage.service';
 
-@Injectable()
+export class ArtworkSeriesDto {
+  id: string;
+  order: number;
+  translations: SeriesTranslation[];
+
+  constructor(seriesArtwork: SeriesArtwork) {
+    this.id = seriesArtwork.seriesId;
+    this.order = seriesArtwork.order;
+    this.translations = seriesArtwork.series?.translations || [];
+  }
+}
+
 export class ArtworkResponseDto {
   id: string;
   imageUrl: string;
@@ -16,9 +27,12 @@ export class ArtworkResponseDto {
   isVertical: boolean;
   translations: ArtworkTranslation[];
   genres: GenreResponseDto[];
-  series: string | null; // TODO: SeriesArtworkResponseDto 구현 시 수정할 것
+  series: ArtworkSeriesDto | null;
 
   constructor(storageService: StorageService, artwork: Artwork) {
+    const seriesArtwork =
+      artwork.seriesArtworks?.length > 0 ? artwork.seriesArtworks[0] : null;
+
     this.id = artwork.id;
     this.imageUrl = storageService.getImageUrl(artwork.imageKey);
     this.createdAt = artwork.createdAt?.toISOString() ?? '';
@@ -29,11 +43,10 @@ export class ArtworkResponseDto {
     this.translations = artwork.translations ?? [];
     this.genres =
       artwork.genres?.map((genre) => new GenreResponseDto(genre)) ?? [];
-    this.series = null; // TODO: SeriesArtworkResponseDto 구현 시 수정할 것
+    this.series = seriesArtwork ? new ArtworkSeriesDto(seriesArtwork) : null;
   }
 }
 
-@Injectable()
 export class ArtworkListResponseDto {
   items: ArtworkResponseDto[];
   metadata: {

--- a/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
+++ b/packages/backend/src/modules/artworks/dtos/artwork-response.dto.ts
@@ -31,7 +31,7 @@ export class ArtworkResponseDto {
 
   constructor(storageService: StorageService, artwork: Artwork) {
     const seriesArtwork =
-      artwork.seriesArtworks?.length > 0 ? artwork.seriesArtworks[0] : null;
+      artwork.seriesArtworks?.length > 0 ? artwork.seriesArtworks[0] : null; // NOTE: 작품에 연결되는 시리즈는 하나만 존재
 
     this.id = artwork.id;
     this.imageUrl = storageService.getImageUrl(artwork.imageKey);


### PR DESCRIPTION
## 관련 이슈
#113 

## 작업 내용
- 리스폰스에 시리즈 추가
- 리포지토리의 연결 테이블 관련 설정 수정
