### PR TITLE
feat: create ping services cron job for keeping alive

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,18 @@
+name: Keep Services Alive
+
+on:
+  schedule:
+    - cron: "0/14 * * * *"
+
+jobs:
+  ping-services:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping All Services (Optimized)
+        run: |
+          curl -s "https://minhoyun.life/api/health/liveness" > /dev/null &
+          curl -s "https://cms.minhoyun.life" > /dev/null &
+          curl -s "https://fanarts.minhoyun.life" > /dev/null &
+          wait
+
+          echo "All services pinged at $(date)"


### PR DESCRIPTION
## 관련 이슈
-

## 작업 내용
- 인프라 이행 작업의 일환으로, 서비스의 다운타임이 없도록 주기적으로 핑하는 크론 잡을 설정
